### PR TITLE
Scope refactor diligence comments

### DIFF
--- a/lib/diggit/analysis/pipeline.rb
+++ b/lib/diggit/analysis/pipeline.rb
@@ -18,7 +18,13 @@ module Diggit
       def aggregate_comments
         REPORTERS.map do |report|
           info { "Generating #{report} for #{repo_label}" }
-          with_temp_repo { report.new(repo, files_changed: files_changed).comments }
+          with_temp_repo do
+            report.
+              new(repo,
+                  files_changed: files_changed,
+                  base: base,
+                  head: head).comments
+          end
         end.flatten
       end
 

--- a/lib/diggit/analysis/refactor_diligence/commit_scanner.rb
+++ b/lib/diggit/analysis/refactor_diligence/commit_scanner.rb
@@ -20,7 +20,7 @@ module Diggit
         attr_reader :repo, :logger
 
         def checkout(ref)
-          repo.reset_hard(ref)
+          repo.checkout(ref, force: true)
           repo.object(ref)
         end
 

--- a/spec/diggit/analysis/pipeline_spec.rb
+++ b/spec/diggit/analysis/pipeline_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe(Diggit::Analysis::Pipeline) do
   # rubocop:disable Lint/UnusedBlockArgument
   def mock_reporter(mock_comments, &block)
     Class.new do
-      define_method(:initialize) { |repo, files_changed:| yield repo if block }
+      define_method(:initialize) { |repo, conf| yield repo if block }
       define_method(:comments) { mock_comments }
     end
   end

--- a/spec/diggit/analysis/refactor_diligence/method_size_history_spec.rb
+++ b/spec/diggit/analysis/refactor_diligence/method_size_history_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::MethodSizeHistory) do
   before do
     allow(instance).to receive(:scan).
       with(:first_commit, files: anything).
-      and_return('fetch' => 3, 'push' => 3, 'bad_idea' => 5)
+      and_return('fetch' => 3, 'bad_idea' => 5)
 
     allow(instance).to receive(:scan).
       with(:second_commit, files: anything).
@@ -24,15 +24,15 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::MethodSizeHistory) do
     subject(:history) { instance.history(commits, restrict_to: []).to_h }
 
     it 'stops tracking after refactor (size reduction)' do
-      expect(history['fetch']).not_to include(3)
+      expect(history['fetch'].map(&:first)).not_to include(3)
     end
 
-    it 'aggregates method sizes into an array' do
-      expect(history).to include('fetch' => [5, 2])
+    it 'aggregates method sizes into sha-size tuples' do
+      expect(history).to include('fetch' => [[5, :third_commit], [2, :second_commit]])
     end
 
-    it 'removes duplicate entries for same size' do
-      expect(history).to include('push' => [3])
+    it 'removes duplicate entries for same size, taking oldest sha' do
+      expect(history).to include('push' => [[3, :second_commit]])
     end
   end
 
@@ -42,13 +42,19 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::MethodSizeHistory) do
     its(:count) { is_expected.to eql(commits.count) }
 
     it 'only tracks methods present in first commit' do
-      sizes.each { |methods| expect(methods.keys).not_to include('bad_idea') }
+      sizes.each { |(methods)| expect(methods.keys).not_to include('bad_idea') }
+    end
+
+    it 'does not list methods beyond their creation' do
+      expect(sizes[2].first.keys).not_to include('push')
     end
 
     it 'tracks method sizes in reverse order' do
-      expect(sizes[0].to_h).to eql('fetch' => 5, 'push' => 3)
-      expect(sizes[1].to_h).to eql('fetch' => 2, 'push' => 3)
-      expect(sizes[2].to_h).to eql('fetch' => 3, 'push' => 3)
+      expect(sizes[0].first.to_h).to eql('fetch' => 5, 'push' => 3)
+      expect(sizes[1].first.to_h).to eql('fetch' => 2, 'push' => 3)
+      expect(sizes[2].first.to_h).to eql('fetch' => 3)
+
+      expect(sizes.map(&:second)).to eql([:third_commit, :second_commit, :first_commit])
     end
   end
 end

--- a/spec/diggit/analysis/refactor_diligence/report_spec.rb
+++ b/spec/diggit/analysis/refactor_diligence/report_spec.rb
@@ -5,8 +5,9 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::Report) do
   subject(:report) { described_class.new(repo, files_changed: files_changed) }
   let(:repo) { refactor_diligence_test_repo }
 
-  let(:head) { repo.log.first.sha }
-  let(:base) { repo.log.last.sha }
+  let(:head) { 'feature' }
+  let(:base) { 'master' }
+
   let(:files_changed) { repo.diff(base, head).stats.fetch(:files).keys }
 
   before { stub_const("#{described_class}::TIMES_INCREASED_THRESHOLD", threshold) }
@@ -14,6 +15,11 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::Report) do
 
   describe '#comments' do
     subject(:comments) { report.comments }
+
+    it 'does not include methods that have not increased in size in this diff' do
+      master_comment = comments.find { |c| c[:meta][:method_name][/Master::initialize/] }
+      expect(master_comment).to be_nil
+    end
 
     it 'include methods that are above threshold', :aggregate_failures do
       socket_comment = comments.find { |c| c[:meta][:method_name][/Socket::initialize/] }

--- a/spec/diggit/analysis/refactor_diligence/test_repo.rb
+++ b/spec/diggit/analysis/refactor_diligence/test_repo.rb
@@ -3,6 +3,33 @@ require_relative '../temporary_analysis_repo'
 # rubocop:disable Metrics/MethodLength, Style/AlignParameters
 def refactor_diligence_test_repo
   TemporaryAnalysisRepo.new.tap do |repo|
+    repo.write('master.rb',
+    %(class Master
+        def initialize
+        end
+      end))
+    repo.commit('initial Master::initialize')
+
+    repo.write('master.rb',
+    %(class Master
+        def initialize
+          puts('first line')
+        end
+      end))
+    repo.commit('Master::initialize +1')
+
+    repo.write('master.rb',
+    %(class Master
+        def initialize
+          puts('first line')
+          puts('second line')
+        end
+      end))
+    repo.commit('Master::initialize +2')
+
+    # Start feature branch here
+    repo.g.branch('feature').checkout
+
     repo.write('file.rb',
     %(module Utils
         class Socket
@@ -37,6 +64,16 @@ def refactor_diligence_test_repo
             @port = port
             puts("Created new socket on \#{host}:\#{port}")
           end
+        end
+      end))
+    repo.write('master.rb',
+    %(class Master
+        def initialize
+          puts('first line')
+          puts('second line')
+        end
+
+        def add_a_method
         end
       end))
     repo.commit('.from_uri and log')


### PR DESCRIPTION
Refactor diligence will currently comment on any methods in changed files that are over the threshold. This means pull requests that touch files with methods over the threshold will receive comments even if the diff doesn't increase the method size.

## Problem case

Take a git repo with two branches, `master` and `feature`. `master` contains three commits modifying our main `master.rb` file to increase a method `Master::initialize` in size three times consecutively, and `Master::hello` twice.

```ruby
# master.rb in master branch
class Master
  def initialize
    puts('one')
    puts('two')
    puts('three')
  end
  
  def hello
    puts('world')
  end
end
```

We then branch from `master` to create `feature`, in which we make a change to `Master::hello` to increase the method size by 1. This now introduces a chain of commits that increase `Master::hello` in size for three consecutive changes, and therefore we should trigger a refactor diligence warning. We pull request `feature`, and diggit runs the analysis.

_As it stands, comments will be made on both `Master::initialize` and `Master::hello` as the report will not discriminate between size increases that have happened outside of the `master~feature` diff._