### PR TITLE
Rolls own db migration deploy tasks

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -8,7 +8,6 @@ require 'capistrano/deploy'
 require 'capistrano/bundler'
 require 'capistrano/passenger'
 require 'capistrano/rbenv'
-require 'capistrano/rails/migrations'
 require 'capistrano/npm'
 
 # Load custom tasks from `lib/capistrano/tasks`

--- a/Gemfile
+++ b/Gemfile
@@ -33,7 +33,6 @@ group :development do
   gem 'capistrano-bundler'
   gem 'capistrano-passenger'
   gem 'capistrano-rbenv'
-  gem 'capistrano-rails'
   gem 'capistrano-npm'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,9 +46,6 @@ GEM
       capistrano (>= 3.0.0)
     capistrano-passenger (0.2.0)
       capistrano (~> 3.0)
-    capistrano-rails (1.1.6)
-      capistrano (~> 3.1)
-      capistrano-bundler (~> 1.1)
     capistrano-rbenv (2.0.4)
       capistrano (~> 3.1)
       sshkit (~> 1.3)
@@ -200,7 +197,6 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-npm
   capistrano-passenger
-  capistrano-rails
   capistrano-rbenv
   coach
   colorize

--- a/Rakefile
+++ b/Rakefile
@@ -1,29 +1,2 @@
 require_relative 'lib/tasks/db'
 require_relative 'lib/tasks/integ'
-
-namespace :deploy do
-  desc 'Deploy diggit'
-  task :production, [:branch] do |_t, args|
-    app = 'diggit'
-    remote = "https://git.heroku.com/#{app}.git"
-    branch = args.fetch(:branch, 'master')
-
-    system "heroku maintenance:on --app #{app}"
-    system "git push --force #{remote} #{branch}:master"
-    system 'heroku run rake db:migrate db:que_setup'
-    system "heroku maintenance:off --app #{app}"
-
-    system 'echo "Pinging diggit... " && curl https://diggit.herokuapp.com/api/ping'
-  end
-end
-
-namespace :heroku do
-  desc 'Configures node & ruby buildpacks for heroku'
-  task :configure_buildpacks do
-    puts('Resetting heroku buildpacks...')
-    system 'heroku buildpacks:clear'
-    system 'heroku buildpacks:add heroku/nodejs'
-    system 'heroku buildpacks:add heroku/ruby'
-    puts('Done!')
-  end
-end

--- a/lib/capistrano/tasks/db.rake
+++ b/lib/capistrano/tasks/db.rake
@@ -1,0 +1,27 @@
+namespace :db do
+  desc 'Runs rake db:migrate if migrations are set'
+  task :migrate do
+    on roles(:app) do
+      info '[deploy:migrate] Checking changes in /db/migrate'
+      if test("diff -q #{release_path}/db/migrate #{current_path}/db/migrate")
+        info '[deploy:migrate] Skip `deploy:migrate` (nothing changed in db/migrate)'
+      else
+        info '[deploy:migrate] Run `rake db:migrate`'
+        invoke :'deploy:migrating'
+      end
+    end
+  end
+
+  desc 'Runs rake db:migrate'
+  task :migrating do
+    on roles(:app) do
+      within release_path do
+        with rack_env: fetch(:stage) do
+          execute :rake, 'db:migrate'
+        end
+      end
+    end
+  end
+
+  after 'bundler:install', 'db:migrate'
+end


### PR DESCRIPTION
capistrano/rails/migrations was failing when deploying. This
implements the default behaviour of migrating on deploy.