### PR TITLE
Fixes bad git reference, empty comment errors

### DIFF
--- a/lib/diggit/analysis/pipeline.rb
+++ b/lib/diggit/analysis/pipeline.rb
@@ -7,12 +7,15 @@ module Diggit
   module Analysis
     class Pipeline
       REPORTERS = [RefactorDiligence::Report].freeze
+      class BadGitHistory < StandardError; end
       include InstanceLogger
 
       def initialize(repo, head:, base:)
         @repo = repo
         @head = head
         @base = base
+
+        verify_head!
       end
 
       def aggregate_comments
@@ -31,6 +34,12 @@ module Diggit
       private
 
       attr_reader :repo, :head, :base
+
+      def verify_head!
+        repo.show(head)
+      rescue Git::GitExecuteError
+        raise BadGitHistory, "Missing head commit #{head}"
+      end
 
       def repo_label
         File.basename(repo.dir.path)

--- a/lib/diggit/models/pull_analysis.rb
+++ b/lib/diggit/models/pull_analysis.rb
@@ -1,6 +1,6 @@
 class PullAnalysis < ActiveRecord::Base
   belongs_to :project
-  validates_presence_of :pull, :comments
+  validates_presence_of :pull
   validates_uniqueness_of :pull, scope: :project_id
 
   scope :for_project, ->(gh_path) { joins(:project).where('projects.gh_path' => gh_path) }

--- a/lib/diggit/routes/github_webhooks.rb
+++ b/lib/diggit/routes/github_webhooks.rb
@@ -11,7 +11,7 @@ module Diggit
 
           return response(404, 'not_found') if project.nil?
           return response(200, 'not_watched') unless project.watch
-          return response(200, 'not_open_action') unless pr_action == 'opened'
+          return response(200, 'not_watched_action') unless watched_action?
 
           Jobs::AnalyseProject.
             enqueue(project.id, params['number'],
@@ -31,8 +31,8 @@ module Diggit
           Project.find_by(gh_path: params.fetch('repository', {})['full_name'])
         end
 
-        def pr_action
-          params.fetch('action', '')
+        def watched_action?
+          %w(opened synchronize).include?(params.fetch('action', ''))
         end
       end
     end

--- a/spec/diggit/analysis/pipeline_spec.rb
+++ b/spec/diggit/analysis/pipeline_spec.rb
@@ -59,6 +59,13 @@ RSpec.describe(Diggit::Analysis::Pipeline) do
   before { stub_const('Diggit::Analysis::Pipeline::REPORTERS', reporters) }
   let(:reporters) { [mock_reporter(%w(1a 1b)), mock_reporter(%w(2a 2b))] }
 
+  context 'when the given HEAD sha is not in repo' do
+    let(:head) { 'bad-head-reference' }
+    it 'raises Pipeline::BadGitHistory' do
+      expect { pipeline }.to raise_exception(described_class::BadGitHistory)
+    end
+  end
+
   describe '#aggregate_comments' do
     it 'collects comments from all reporters' do
       expect(pipeline.aggregate_comments).to match_array(%w(1a 1b 2a 2b))

--- a/spec/diggit/jobs/analyse_project_spec.rb
+++ b/spec/diggit/jobs/analyse_project_spec.rb
@@ -42,6 +42,18 @@ RSpec.describe(Diggit::Jobs::AnalyseProject) do
       end
     end
 
+    context 'when referenced commits are no longer in repo' do
+      before do
+        allow(Diggit::Analysis::Pipeline).
+          to receive(:new).
+          and_raise(Diggit::Analysis::Pipeline::BadGitHistory)
+      end
+
+      it 'does not create analysis' do
+        expect { run! }.not_to change(PullAnalysis, :count)
+      end
+    end
+
     shared_examples 'audited analysis' do
       before { comment_generator.as_null_object }
 

--- a/spec/diggit/models/pull_analysis_spec.rb
+++ b/spec/diggit/models/pull_analysis_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe(PullAnalysis) do
 
     it { is_expected.to be_valid }
     it { is_expected.to validate_presence_of(:pull) }
-    it { is_expected.to validate_presence_of(:comments) }
     it { is_expected.to validate_uniqueness_of(:pull).scoped_to(:project_id) }
 
     it { is_expected.to belong_to(:project) }


### PR DESCRIPTION
Empty comment errors
(https://rollbar.com/lawrencejones/diggit-prod/items/12/) were from
ActiveRecord validating presence of pull_analysis.comments prior to
save, despite a database default being in place.

Bad git reference errors
(https://rollbar.com/lawrencejones/diggit-prod/items/10/) caused by
rebasing before the job had been processed, meaning the references
in the pr were no longer found in the repo.