### PR TITLE
Remove feedz notify

### DIFF
--- a/bin/notify-deploy
+++ b/bin/notify-deploy
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-echo -n "Sending deploy notification... "
-curl -X POST \
-     -H 'Content-Type: application/json' \
-     -d "{\"from\": \"Deploy\", \"content\": \"Deployed diggit $(git rev-parse HEAD | cut -c1-8)\"}" \
-     http://diggit-repo.com:45456/broadcast
-echo

--- a/circle.yml
+++ b/circle.yml
@@ -29,4 +29,4 @@ deployment:
   production:
     branch: [master]
     commands:
-      - bundle exec cap production deploy && ./bin/notify-deploy
+      - bundle exec cap production deploy


### PR DESCRIPTION
Rollbar emails a notification whenever the deploy takes place, so
feedz is no longer required.