### PR TITLE
Remove requirement for repo github oauth scope

### DIFF
--- a/lib/diggit.rb
+++ b/lib/diggit.rb
@@ -57,7 +57,7 @@ module Diggit
         router.get '/redirect', to: Coach::Handler.
           new(Routes::Auth::Redirect,
               client_id: config.fetch(:github_client_id),
-              scope: 'write:repo_hook,repo')
+              scope: 'write:repo_hook')
         router.post '/access_token', to: Coach::Handler.
           new(Routes::Auth::CreateAccessToken,
               client_id: config.fetch(:github_client_id),

--- a/lib/diggit/github/cloner.rb
+++ b/lib/diggit/github/cloner.rb
@@ -1,22 +1,33 @@
 module Diggit
   module Github
-    # Facilitates cloning of github repos with a specific ssh private key.
+    # Facilitates cloning of github repos into temporary workspaces
     class Cloner
-      def initialize(ssh_private_key)
-        @ssh_private_key = ssh_private_key
+      def initialize(gh_path)
+        @gh_path = gh_path
       end
 
-      def clone(gh_path)
-        Dir.mktmpdir('cloner') do |scratch|
-          with_temporary_keyfile(@ssh_private_key) do |keyfile|
-            repo = clone_with_keyfile(gh_path, keyfile,
-                                      to: File.join(scratch, gh_path.split('/').last))
-            yield(repo)
+      def clone
+        with_temporary_dir do |temp_dir|
+          Git.clone("https://github.com/#{@gh_path}.git", temp_dir)
+          yield(Git.open(temp_dir))
+        end
+      end
+
+      def clone_with_key(ssh_private_key)
+        with_temporary_dir do |temp_dir|
+          with_temporary_keyfile(ssh_private_key) do |keyfile|
+            yield clone_with_keyfile(keyfile, to: temp_dir)
           end
         end
       end
 
       private
+
+      def with_temporary_dir
+        Dir.mktmpdir('cloner') do |scratch|
+          yield(File.join(scratch, @gh_path.split('/').last))
+        end
+      end
 
       def with_temporary_keyfile(key)
         keyfile = Tempfile.open('private-key')
@@ -29,11 +40,11 @@ module Diggit
 
       # Runs a git clone with a specified private key file. Git clone has to be run in
       # subprocess as we are required to modify the environment.
-      def clone_with_keyfile(gh_path, keyfile, to:)
+      def clone_with_keyfile(keyfile, to:)
         pid = Process.fork do
           begin
             ENV['GIT_SSH_COMMAND'] = "ssh -i #{keyfile}"
-            Git.clone("git@github.com:#{gh_path}", to)
+            Git.clone("git@github.com:#{@gh_path}", to)
           ensure
             Kernel.exit! # required to not screw up socket connections
           end

--- a/lib/diggit/github/repo.rb
+++ b/lib/diggit/github/repo.rb
@@ -56,6 +56,10 @@ module Diggit
         end
       end
 
+      def private
+        @repo[:private]
+      end
+
       private
 
       def path

--- a/lib/diggit/jobs/configure_project_github.rb
+++ b/lib/diggit/jobs/configure_project_github.rb
@@ -18,12 +18,14 @@ module Diggit
         gh_client = Octokit::Client.new(access_token: gh_token)
         repo = Github::Repo.from_path(project.gh_path, gh_client)
 
-        info { "Set #{Github.login} as collaborator..." }
-        repo.add_collaborator(Github.login)
+        if repo.private
+          info { "Set #{Github.login} as collaborator..." }
+          repo.add_collaborator(Github.login)
 
-        info { "Configuring deploy key on #{project.gh_path}..." }
-        project.generate_keypair! unless project.keys?
-        repo.setup_deploy_key!(title: "Diggit - #{env}", key: project.ssh_public_key)
+          info { "Configuring deploy key on #{project.gh_path}..." }
+          project.generate_keypair! unless project.keys?
+          repo.setup_deploy_key!(title: "Diggit - #{env}", key: project.ssh_public_key)
+        end
 
         info { "Configuring webhooks on #{project.gh_path}..." }
         repo.setup_webhook!(webhook_endpoint)

--- a/spec/diggit/github/cloner_spec.rb
+++ b/spec/diggit/github/cloner_spec.rb
@@ -1,7 +1,7 @@
 require 'diggit/github/cloner'
 
 RSpec.describe(Diggit::Github::Cloner) do
-  subject(:cloner) { described_class.new(ssh_private_key) }
+  subject(:cloner) { described_class.new(gh_path) }
 
   let(:ssh_private_key) { 'ssh-private-key' }
   let(:gh_path) { 'lawrencejones/diggit' }
@@ -18,9 +18,18 @@ RSpec.describe(Diggit::Github::Cloner) do
 
   describe '.clone' do
     it 'yields with repo' do
-      cloner.clone(gh_path) do |repo|
+      cloner.clone do |repo|
         expect(repo).to be_instance_of(Git::Base)
-        expect(repo.ls_files.keys).to eql(['remote'])
+        expect(repo.show('HEAD', 'remote')).to start_with('https://github.com/')
+      end
+    end
+  end
+
+  describe '.clone_with_key' do
+    it 'yields with repo' do
+      cloner.clone_with_key(ssh_private_key) do |repo|
+        expect(repo).to be_instance_of(Git::Base)
+        expect(repo.show('HEAD', 'remote')).to start_with('git@github.com:')
       end
     end
   end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -5,6 +5,9 @@ FactoryGirl.define do
 
     trait :watched do
       watch true
+    end
+
+    trait :deploy_keys do
       ssh_public_key 'ssh-public-key'
       ssh_private_key 'ssh-private-key'
     end


### PR DESCRIPTION
Without this, we cannot see private github repos, but should make
signing up less threatening than requesting access to all-of-the-things.