### PR TITLE
PullAnalysis for every new change

### DIFF
--- a/db/migrate/20160506115032_make_base_head_non_null_on_pull_analysis.rb
+++ b/db/migrate/20160506115032_make_base_head_non_null_on_pull_analysis.rb
@@ -1,0 +1,8 @@
+class MakeBaseHeadNonNullOnPullAnalysis < ActiveRecord::Migration
+  def change
+    change_column_null :pull_analyses, :base, false
+    change_column_null :pull_analyses, :head, false
+
+    add_index :pull_analyses, %i(project_id pull base head), unique: true
+  end
+end

--- a/db/migrate/20160506125119_add_pushed_to_github_to_pull_analysis.rb
+++ b/db/migrate/20160506125119_add_pushed_to_github_to_pull_analysis.rb
@@ -1,0 +1,13 @@
+class AddPushedToGithubToPullAnalysis < ActiveRecord::Migration
+  def up
+    add_column :pull_analyses, :pushed_to_github, :boolean, null: false, default: false
+    execute <<-SQL
+    UPDATE pull_analyses
+       SET pushed_to_github=True;
+    SQL
+  end
+
+  def down
+    remove_column :pull_analyses, :pushed_to_github, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506110833) do
+ActiveRecord::Schema.define(version: 20160506125119) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,14 +28,16 @@ ActiveRecord::Schema.define(version: 20160506110833) do
 
   create_table "pull_analyses", force: :cascade do |t|
     t.integer  "project_id"
-    t.integer  "pull",                    null: false
-    t.json     "comments",   default: [], null: false
-    t.datetime "created_at",              null: false
-    t.datetime "updated_at",              null: false
-    t.text     "base"
-    t.text     "head"
+    t.integer  "pull",                             null: false
+    t.json     "comments",         default: [],    null: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
+    t.text     "base",                             null: false
+    t.text     "head",                             null: false
+    t.boolean  "pushed_to_github", default: false, null: false
   end
 
+  add_index "pull_analyses", ["project_id", "pull", "base", "head"], name: "index_pull_analyses_on_project_id_and_pull_and_base_and_head", unique: true, using: :btree
   add_index "pull_analyses", ["project_id"], name: "index_pull_analyses_on_project_id", using: :btree
 
   create_table "que_jobs", id: false, force: :cascade do |t|

--- a/lib/diggit/analysis/complexity/report.rb
+++ b/lib/diggit/analysis/complexity/report.rb
@@ -36,6 +36,7 @@ module Diggit
         def generate_comments
           files_above_threshold.to_h.map do |file, (complexity_increase, head, base)|
             { report: 'Complexity',
+              index: file,
               location: "#{file}:1",
               message: "`#{file}` has increased in complexity by "\
                        "#{complexity_increase.to_i}% over the last "\

--- a/lib/diggit/analysis/refactor_diligence/report.rb
+++ b/lib/diggit/analysis/refactor_diligence/report.rb
@@ -25,6 +25,7 @@ module Diggit
         def generate_comments
           methods_over_threshold.to_h.map do |method, history|
             { report: 'RefactorDiligence',
+              index: method,
               location: method_locations.fetch(method),
               message: "#{method} has increased in size the last "\
                        "#{history.size} times it has been modified - "\

--- a/lib/diggit/jobs/analyse_pull.rb
+++ b/lib/diggit/jobs/analyse_pull.rb
@@ -2,38 +2,36 @@ require 'que'
 require 'git'
 require 'tempfile'
 
+require_relative 'push_analysis_comments'
 require_relative '../logger'
 require_relative '../models/project'
 require_relative '../models/pull_analysis'
 require_relative '../analysis/pipeline'
-require_relative '../github/client'
-require_relative '../github/comment_generator'
 require_relative '../github/cloner'
 
 module Diggit
   module Jobs
-    class AnalyseProject < Que::Job
+    class AnalysePull < Que::Job
       include InstanceLogger
 
       def run(project_id, pull, head, base)
         @pull = pull
+        @head = head
+        @base = base
         @project = Project.find(project_id)
         @cloner = Github::Cloner.new(project.gh_path)
-        @comment_generator = Github::CommentGenerator.
-          new(project.gh_path, pull, Github.client)
 
         return destroy unless validate
 
         ActiveRecord::Base.transaction do
-          run_analysis(head, base)
+          create_analysis
           destroy
         end
       end
 
       private
 
-      attr_reader :project, :cloner, :comment_generator, :pull
-      delegate :add_comment, to: :comment_generator
+      attr_reader :project, :cloner, :pull, :head, :base
 
       def validate
         unless project && project.watch
@@ -41,7 +39,7 @@ module Diggit
           return false
         end
 
-        if PullAnalysis.exists?(project: project, pull: pull)
+        if PullAnalysis.exists?(project: project, pull: pull, head: head, base: base)
           info { "Pull #{pull} for #{project.gh_path} already analysed, doing nothing" }
           return false
         end
@@ -49,10 +47,10 @@ module Diggit
         true
       end
 
-      def run_analysis(head, base)
+      def create_analysis
         comments = generate_comments(head, base)
-        create_pull_analysis(pull, comments)
-        comment_to_github(comments)
+        pull_analysis = create_pull_analysis(pull, comments)
+        PushAnalysisComments.enqueue(pull_analysis.id)
       rescue Analysis::Pipeline::BadGitHistory
         info { "Pull #{pull} references commits that no longer exist, skipping analysis" }
       end
@@ -73,13 +71,10 @@ module Diggit
 
       def create_pull_analysis(pull, comments)
         info { 'Creating PullAnalysis record...' }
-        PullAnalysis.create!(project: project, pull: pull, comments: comments)
-      end
-
-      def comment_to_github(comments)
-        comments.each { |comment| add_comment(comment[:message], comment[:location]) }
-        info { "Pushing #{comment_generator.pending} comments to github..." }
-        comment_generator.push
+        PullAnalysis.create!(project: project,
+                             pull: pull,
+                             head: head, base: base,
+                             comments: comments)
       end
     end
   end

--- a/lib/diggit/jobs/push_analysis_comments.rb
+++ b/lib/diggit/jobs/push_analysis_comments.rb
@@ -1,0 +1,63 @@
+require 'que'
+
+require_relative '../logger'
+require_relative '../models/project'
+require_relative '../models/pull_analysis'
+require_relative '../github/comment_generator'
+require_relative '../github/client'
+
+module Diggit
+  module Jobs
+    class PushAnalysisComments < Que::Job
+      include InstanceLogger
+
+      def run(pull_analysis_id)
+        @pull_analysis = PullAnalysis.find(pull_analysis_id)
+        @comment_generator = Github::CommentGenerator.
+          new(project.gh_path, pull_analysis.pull, Github.client)
+
+        if pull_analysis.pushed_to_github
+          info { "Already commented for analysis #{pull_analysis.id}, doing nothing" }
+          return destroy
+        end
+
+        ActiveRecord::Base.transaction do
+          push_comments_to_github
+          pull_analysis.update!(pushed_to_github: true)
+          destroy
+        end
+      end
+
+      private
+
+      attr_reader :pull_analysis, :comment_generator
+      delegate :project, to: :pull_analysis
+
+      def push_comments_to_github
+        pending_comments.each do |comment|
+          comment_generator.add_comment(comment['message'], comment['location'])
+        end
+        info { "Pushing #{pending_comments.count} comments to github..." }
+        comment_generator.push
+      end
+
+      def pending_comments
+        @pending_comments ||= pull_analysis.comments.reject do |comment|
+          existing_comments.include?(comment.slice('report', 'index'))
+        end
+      end
+
+      def existing_comments
+        @existing_comments ||= existing_analyses.
+          flat_map(&:comments).
+          map { |comment| comment.slice('report', 'index') }
+      end
+
+      def existing_analyses
+        PullAnalysis.
+          where(project: project, pull: pull_analysis.pull).
+          where.not(id: pull_analysis.id)
+      end
+    end
+  end
+end

--- a/lib/diggit/models/pull_analysis.rb
+++ b/lib/diggit/models/pull_analysis.rb
@@ -1,7 +1,7 @@
 class PullAnalysis < ActiveRecord::Base
   belongs_to :project
-  validates_presence_of :pull
-  validates_uniqueness_of :pull, scope: :project_id
+  validates_presence_of :pull, :head, :base
+  validates_uniqueness_of :pull, scope: %i(project_id base head)
 
   scope :for_project, ->(gh_path) { joins(:project).where('projects.gh_path' => gh_path) }
 end

--- a/lib/diggit/routes/github_webhooks.rb
+++ b/lib/diggit/routes/github_webhooks.rb
@@ -1,5 +1,5 @@
 require 'coach'
-require_relative '../jobs/analyse_project'
+require_relative '../jobs/analyse_pull'
 require_relative '../models/project'
 
 module Diggit
@@ -13,7 +13,7 @@ module Diggit
           return response(200, 'not_watched') unless project.watch
           return response(200, 'not_watched_action') unless watched_action?
 
-          Jobs::AnalyseProject.
+          Jobs::AnalysePull.
             enqueue(project.id, params['number'],
                     params['pull_request']['head']['sha'],
                     params['pull_request']['base']['sha'])

--- a/lib/tasks/one_off.rb
+++ b/lib/tasks/one_off.rb
@@ -2,17 +2,4 @@ require_relative '../diggit/system'
 Diggit::System.init
 
 namespace :one_off do
-  task :backfill_pull_analyses do
-    Diggit.logger.info("Backfilling #{PullAnalysis.count} pull analyses...")
-    ActiveRecord::Base.transaction do
-      PullAnalysis.all.each do |pull_analysis|
-        pull = Diggit::Github.client.pull(pull_analysis.project.gh_path,
-                                          pull_analysis.pull)
-        pull_analysis.update(base: pull.base.sha, head: pull.head.sha)
-        Diggit.logger.
-          info("[#{pull_analysis.project.gh_path}##{pull_analysis.pull}] Updated!")
-      end
-    end
-    Diggit.logger.info('Backfill done!')
-  end
 end

--- a/spec/diggit/analysis/complexity/report_spec.rb
+++ b/spec/diggit/analysis/complexity/report_spec.rb
@@ -72,6 +72,7 @@ RSpec.describe(Diggit::Analysis::Complexity::Report) do
             report: 'Complexity',
             message: /increased in complexity by 58% over the last 12 days/,
             location: 'master.rb:1',
+            index: 'master.rb',
             meta: {
               file: 'master.rb',
               complexity_increase: 58.33,

--- a/spec/diggit/jobs/push_analysis_comments_spec.rb
+++ b/spec/diggit/jobs/push_analysis_comments_spec.rb
@@ -1,0 +1,101 @@
+require 'diggit/jobs/push_analysis_comments'
+
+RSpec.describe(Diggit::Jobs::PushAnalysisComments) do
+  subject(:job) { described_class.new({}) }
+  let(:run!) { job.run(pull_analysis.id) }
+
+  let(:head) { 'head-sha' }
+  let(:base) { 'base-sha' }
+  let(:pushed_to_github) { false }
+
+  let!(:pull_analysis) do
+    FactoryGirl.create(:pull_analysis,
+                       pushed_to_github: pushed_to_github, comments: comments,
+                       base: base, head: head)
+  end
+  let(:comments) do
+    [{ report: 'Complexity',
+       index: 'file.rb',
+       message: 'increased in complexity by 50% over last 7 days',
+       location: 'file.rb:1' },
+     { report: 'RefactorDiligence',
+       index: 'Socket::initialize',
+       message: 'Socket::initialize has increase in size the last 3 times',
+       location: 'socket.rb:20' }]
+  end
+
+  let(:comment_generator) { instance_double(Diggit::Github::CommentGenerator) }
+  let(:gh_client) { instance_double(Octokit::Client) }
+
+  before do
+    allow(Diggit::Github).to receive(:client).and_return(gh_client)
+    allow(Diggit::Github::CommentGenerator).to receive(:new).and_return(comment_generator)
+
+    allow(comment_generator).to receive(:add_comment)
+    allow(comment_generator).to receive(:push)
+    expect(job).to receive(:destroy)
+  end
+
+  shared_examples 'audited comment job' do
+    it 'sets pushed_to_github=true' do
+      expect { run! }.
+        to change { pull_analysis.reload.pushed_to_github }.
+        from(false).to(true)
+    end
+  end
+
+  context 'when analysis has already been pushed_to_github' do
+    let(:pushed_to_github) { true }
+
+    it 'does nothing' do
+      expect(comment_generator).not_to receive(:push)
+      run!
+    end
+  end
+
+  context 'when there are no existing analyses for this pull' do
+    it_behaves_like 'audited comment job'
+
+    it 'sends all comments to github' do
+      expect(comment_generator).
+        to receive(:add_comment).
+        with('increased in complexity by 50% over last 7 days', 'file.rb:1')
+      expect(comment_generator).
+        to receive(:add_comment).
+        with('Socket::initialize has increase in size the last 3 times', 'socket.rb:20')
+      expect(comment_generator).to receive(:push)
+      run!
+    end
+  end
+
+  context 'when analyses exist for this pull' do
+    let!(:existing_pull_analysis) do
+      FactoryGirl.create(:pull_analysis,
+                         comments: existing_comments, base: base, head: 'old-head-sha')
+    end
+    let(:existing_comments) do
+      [{ report: 'RefactorDiligence',
+         index: 'Socket::initialize',
+         message: 'Socket::initialize has increase in size the last 3 times',
+         location: 'socket.rb:15' }]
+    end
+
+    it_behaves_like 'audited comment job'
+
+    it 'sends new comments to github' do
+      expect(comment_generator).
+        to receive(:add_comment).
+        with('increased in complexity by 50% over last 7 days', 'file.rb:1')
+      expect(comment_generator).to receive(:push)
+      run!
+    end
+
+    it 'does not send existing comments to github' do
+      expect(comment_generator).
+        not_to receive(:add_comment).
+        with('Socket::initialize has increase in size the last 3 times', 'socket.rb:15')
+      expect(comment_generator).to receive(:push)
+      run!
+    end
+  end
+end

--- a/spec/diggit/models/pull_analysis_spec.rb
+++ b/spec/diggit/models/pull_analysis_spec.rb
@@ -9,7 +9,11 @@ RSpec.describe(PullAnalysis) do
 
     it { is_expected.to be_valid }
     it { is_expected.to validate_presence_of(:pull) }
-    it { is_expected.to validate_uniqueness_of(:pull).scoped_to(:project_id) }
+    it { is_expected.to validate_presence_of(:head) }
+    it { is_expected.to validate_presence_of(:base) }
+    it do
+      is_expected.to validate_uniqueness_of(:pull).scoped_to(:project_id, :base, :head)
+    end
 
     it { is_expected.to belong_to(:project) }
   end

--- a/spec/diggit/routes/github_webhooks_spec.rb
+++ b/spec/diggit/routes/github_webhooks_spec.rb
@@ -22,8 +22,8 @@ RSpec.describe(Diggit::Routes::GithubWebhooks::Create) do
   before { Que.mode = :off }
 
   shared_examples 'ignores webhook' do |status, body|
-    it 'does not queue AnalyseProject job' do
-      expect(Diggit::Jobs::AnalyseProject).
+    it 'does not queue AnalysePull job' do
+      expect(Diggit::Jobs::AnalysePull).
         not_to receive(:enqueue)
       instance.call
     end
@@ -36,8 +36,8 @@ RSpec.describe(Diggit::Routes::GithubWebhooks::Create) do
     it { is_expected.to respond_with_status(200) }
     it { is_expected.to respond_with_json('message' => 'project_analysis_queued') }
 
-    it 'enqueues AnalyseProject job' do
-      expect(Diggit::Jobs::AnalyseProject).
+    it 'enqueues AnalysePull job' do
+      expect(Diggit::Jobs::AnalysePull).
         to receive(:enqueue).
         with(project.id, webhook['number'], head, base)
       instance.call

--- a/spec/factories/pull_analysis.rb
+++ b/spec/factories/pull_analysis.rb
@@ -2,6 +2,9 @@ FactoryGirl.define do
   factory :pull_analysis do
     sequence(:pull)
     comments [{ 'message' => 'bazinga!' }]
+    head 'head-sha'
+    base 'base-sha'
+    pushed_to_github false
     project
   end
 end


### PR DESCRIPTION
Changes how a PullAnalysis is used, by creating new records for every change detected on a pull request. This diff involves splitting the `AnalyseProject` job in two, with one subjob creating the analysis and another dealing with sending comments to Github.