### PR TITLE
GithubPoller

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -16,3 +16,6 @@ end
 
 use(Rollbar::Middleware::Sinatra)
 run(Diggit::System.rack_app)
+
+require_relative 'lib/diggit/services/github_poller'
+Diggit::Services::GithubPoller.start

--- a/db/migrate/20160506145149_add_polled_to_projects.rb
+++ b/db/migrate/20160506145149_add_polled_to_projects.rb
@@ -1,0 +1,5 @@
+class AddPolledToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :polled, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,17 +11,18 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506125119) do
+ActiveRecord::Schema.define(version: 20160506145149) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "projects", force: :cascade do |t|
-    t.string  "gh_path",                   limit: 126,                null: false
+    t.string  "gh_path",                   limit: 126,                 null: false
     t.boolean "watch",                                 default: true
     t.text    "ssh_public_key"
     t.binary  "encrypted_ssh_private_key"
     t.binary  "ssh_initialization_vector"
+    t.boolean "polled",                                default: false, null: false
   end
 
   add_index "projects", ["gh_path"], name: "index_projects_on_gh_path", unique: true, using: :btree

--- a/lib/diggit/jobs/analyse_pull.rb
+++ b/lib/diggit/jobs/analyse_pull.rb
@@ -14,11 +14,11 @@ module Diggit
     class AnalysePull < Que::Job
       include InstanceLogger
 
-      def run(project_id, pull, head, base)
+      def run(gh_path, pull, head, base)
         @pull = pull
         @head = head
         @base = base
-        @project = Project.find(project_id)
+        @project = Project.find_by!(gh_path: gh_path)
         @cloner = Github::Cloner.new(project.gh_path)
 
         return destroy unless validate

--- a/lib/diggit/jobs/poll_github.rb
+++ b/lib/diggit/jobs/poll_github.rb
@@ -1,0 +1,58 @@
+require 'que'
+
+require_relative 'analyse_pull'
+require_relative '../logger'
+require_relative '../models/project'
+require_relative '../models/pull_analysis'
+require_relative '../github/client'
+
+module Diggit
+  module Jobs
+    # Looks through all Projects that are set for polling, and enqueues AnalysePull jobs
+    # for any that have un-analysed pulls.
+    class PollGithub < Que::Job
+      include InstanceLogger
+
+      def run
+        if polled_projects.empty?
+          info { 'No projects are set to poll, doing nothing' }
+          return destroy
+        end
+
+        ActiveRecord::Base.transaction do
+          polled_projects.each { |project| poll(project) }
+          destroy
+        end
+      end
+
+      def poll(project)
+        info { "Polling #{project.gh_path} for new PRs..." }
+        Github.client.pulls(project.gh_path).each do |pull|
+          queue_analysis(pull, project) unless pull_analysis_exists?(pull)
+        end
+      end
+
+      def queue_analysis(pull, project)
+        info { "Queue analysis for #{project.gh_path}/pulls/#{pull[:number]}" }
+        AnalysePull.
+          enqueue(project.gh_path,
+                  pull[:number],
+                  pull[:head][:sha],
+                  pull[:base][:sha])
+      end
+
+      def pull_analysis_exists?(pull)
+        PullAnalysis.
+          joins(:project).
+          where('projects.gh_path' => pull[:head][:repo][:full_name]).
+          exists?(pull: pull[:number],
+                  head: pull[:head][:sha],
+                  base: pull[:base][:sha])
+      end
+
+      def polled_projects
+        @polled_projects ||= Project.where(polled: true)
+      end
+    end
+  end
+end

--- a/lib/diggit/routes/github_webhooks.rb
+++ b/lib/diggit/routes/github_webhooks.rb
@@ -14,7 +14,7 @@ module Diggit
           return response(200, 'not_watched_action') unless watched_action?
 
           Jobs::AnalysePull.
-            enqueue(project.id, params['number'],
+            enqueue(project.gh_path, params['number'],
                     params['pull_request']['head']['sha'],
                     params['pull_request']['base']['sha'])
 

--- a/lib/diggit/services/github_poller.rb
+++ b/lib/diggit/services/github_poller.rb
@@ -1,0 +1,35 @@
+require 'que'
+
+require_relative '../jobs/poll_github'
+require_relative '../models/pull_analysis'
+require_relative '../models/project'
+
+module Diggit
+  module Services
+    # Uses Que to schedule the PollGithub job on regular intervals. Only one POLL_JOB is
+    # to be enqueued at any time.
+    class GithubPoller
+      POLLING_INTERVAL = 30 # seconds
+      POLL_JOB = Jobs::PollGithub
+
+      def self.start
+        @poller = Thread.new do
+          loop do
+            Jobs::PollGithub.enqueue unless already_queued?
+            sleep(POLLING_INTERVAL)
+          end
+        end
+      end
+
+      def self.already_queued?
+        job_status = Que.job_stats.find { |job| job['job_class'] == POLL_JOB.to_s }
+        job_status.present? && (job_status['count'] + job_status['count_working']) > 0
+      end
+
+      def self.kill
+        @poller.kill unless @poller.nil?
+        @poller = nil
+      end
+    end
+  end
+end

--- a/lib/diggit/system.rb
+++ b/lib/diggit/system.rb
@@ -90,7 +90,7 @@ module Diggit
 
     def self.configure_que!
       Que.connection = ActiveRecord
-      Que.mode = :sync  if Prius.get(:diggit_env) == 'test'
+      Que.mode = :off   if Prius.get(:diggit_env) == 'test'
       Que.mode = :async if Prius.get(:diggit_env) == 'development'
       Que.logger = Diggit.logger
     end

--- a/lib/tasks/one_off.rb
+++ b/lib/tasks/one_off.rb
@@ -2,4 +2,22 @@ require_relative '../diggit/system'
 Diggit::System.init
 
 namespace :one_off do
+  desc 'Adds a private repo to be polled'
+  task :add_polled_repo, [:gh_path] do |_, args|
+    if Project.exists?(gh_path: args[:gh_path])
+      puts("Project #{args[:gh_path]} is already watched!")
+    end
+
+    puts("Adding repo #{args[:gh_path]}...")
+    project = ActiveRecord::Base.transaction do
+      Project.
+        create!(gh_path: args[:gh_path],
+                watch: true,
+                polled: true).
+        tap(&:generate_keypair!)
+    end
+    puts('Done!')
+    puts('Add the following public key to Github account with access to this repo:')
+    puts("\n#{project.ssh_public_key}\n")
+  end
 end

--- a/spec/diggit/jobs/analyse_pull_spec.rb
+++ b/spec/diggit/jobs/analyse_pull_spec.rb
@@ -3,7 +3,7 @@ require 'diggit/jobs/analyse_pull'
 
 RSpec.describe(Diggit::Jobs::AnalysePull) do
   subject(:job) { described_class.new({}) }
-  let(:run!) { job.run(project.id, pull, head, base) }
+  let(:run!) { job.run(project.gh_path, pull, head, base) }
 
   let(:project) { FactoryGirl.create(:project, :diggit) }
   let(:pull) { 43 }

--- a/spec/diggit/jobs/poll_github_spec.rb
+++ b/spec/diggit/jobs/poll_github_spec.rb
@@ -1,0 +1,68 @@
+require 'diggit/jobs/poll_github'
+
+RSpec.describe(Diggit::Jobs::PollGithub) do
+  subject(:job) { described_class.new({}) }
+  let(:run!) { job.run }
+
+  let!(:diggit) { FactoryGirl.create(:project, :diggit, watch: true, polled: false) }
+  let!(:payments_service) do
+    FactoryGirl.
+      create(:project,
+             gh_path: 'gocardless/payments_service',
+             watch: true, polled: true)
+  end
+
+  let(:gh_client) { instance_double(Octokit::Client) }
+  before do
+    allow(Diggit::Github).to receive(:client).and_return(gh_client)
+    allow(Diggit::Jobs::AnalysePull).to receive(:enqueue)
+    allow(gh_client).to receive(:pulls)
+  end
+
+  def mock_pull(project, number, head:, base:)
+    { head: { sha: head, repo: { full_name: project.gh_path } },
+      base: { sha: base }, number: number }
+  end
+
+  describe '.run' do
+    let(:head) { 'head-sha' }
+    before do
+      allow(gh_client).
+        to receive(:pulls).
+        with(payments_service.gh_path).
+        and_return([mock_pull(payments_service, 1, base: 'base-sha', head: head)])
+    end
+
+    it 'does not poll github for non-polled projects' do
+      expect(gh_client).not_to receive(:pulls).with(diggit.gh_path)
+      run!
+    end
+
+    context 'when polled project has pulls that have not been analysed' do
+      it 'enqueues analysis' do
+        expect(Diggit::Jobs::AnalysePull).
+          to receive(:enqueue).
+          with(payments_service.gh_path, 1, head, 'base-sha')
+        run!
+      end
+    end
+
+    context 'when pull has been analysed but there are new commits' do
+      let(:head) { 'new-head-sha' }
+      let!(:existing_analysis) do
+        FactoryGirl.create(:pull_analysis,
+                           project: payments_service,
+                           pull: 1,
+                           base: 'base-sha',
+                           head: 'head-sha')
+      end
+
+      it 'enqueues analysis' do
+        expect(Diggit::Jobs::AnalysePull).
+          to receive(:enqueue).
+          with(payments_service.gh_path, 1, head, 'base-sha')
+        run!
+      end
+    end
+  end
+end

--- a/spec/diggit/routes/github_webhooks_spec.rb
+++ b/spec/diggit/routes/github_webhooks_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe(Diggit::Routes::GithubWebhooks::Create) do
     it 'enqueues AnalysePull job' do
       expect(Diggit::Jobs::AnalysePull).
         to receive(:enqueue).
-        with(project.id, webhook['number'], head, base)
+        with(project.gh_path, webhook['number'], head, base)
       instance.call
     end
   end

--- a/spec/diggit/services/github_poller_spec.rb
+++ b/spec/diggit/services/github_poller_spec.rb
@@ -1,0 +1,55 @@
+require 'diggit/services/github_poller'
+
+RSpec.describe(Diggit::Services::GithubPoller) do
+  subject(:poller) { described_class }
+
+  before do
+    # Mock Thread.new to prevent escaping the current thread
+    allow(Thread).
+      to receive(:new).
+      and_yield.
+      and_return(instance_double(Thread).as_null_object)
+
+    # Capture block given to loop
+    allow(poller).to receive(:loop) { |&block| @poll_block = block }
+    stub_const("#{poller}::POLLING_INTERVAL", 0)
+  end
+
+  after { poller.kill }
+
+  describe '.start' do
+    before { poller.start }
+    before { allow(poller).to receive(:already_queued?).and_return(already_queued) }
+
+    context 'when PollGithub is not currently running or queued' do
+      let(:already_queued) { false }
+
+      it 'enqueues new job' do
+        expect(Diggit::Jobs::PollGithub).to receive(:enqueue)
+        @poll_block.call
+      end
+    end
+
+    context 'when PollGithub is already queued' do
+      let(:already_queued) { true }
+
+      it 'does not enqueue job' do
+        expect(Diggit::Jobs::PollGithub).not_to receive(:enqueue)
+        @poll_block.call
+      end
+    end
+  end
+
+  describe '.already_queued?' do
+    subject { poller.already_queued? }
+
+    context 'when PollGithub is already enqueued' do
+      before { Diggit::Jobs::PollGithub.enqueue }
+      it { is_expected.to be(true) }
+    end
+
+    context 'when PollGithub is not enqueued' do
+      it { is_expected.to be(false) }
+    end
+  end
+end


### PR DESCRIPTION
Allows polling of github repositories, rather than waiting for
webhooks. This should facilitate watching of public repos that I
may not have admin rights to.