### PR TITLE
Adds silent field to Projects

### DIFF
--- a/db/migrate/20160506173240_add_silent_to_projects.rb
+++ b/db/migrate/20160506173240_add_silent_to_projects.rb
@@ -1,0 +1,5 @@
+class AddSilentToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :silent, :boolean, null: false, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506145149) do
+ActiveRecord::Schema.define(version: 20160506173240) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -23,6 +23,7 @@ ActiveRecord::Schema.define(version: 20160506145149) do
     t.binary  "encrypted_ssh_private_key"
     t.binary  "ssh_initialization_vector"
     t.boolean "polled",                                default: false, null: false
+    t.boolean "silent",                                default: false, null: false
   end
 
   add_index "projects", ["gh_path"], name: "index_projects_on_gh_path", unique: true, using: :btree

--- a/lib/diggit/jobs/analyse_pull.rb
+++ b/lib/diggit/jobs/analyse_pull.rb
@@ -50,7 +50,7 @@ module Diggit
       def create_analysis
         comments = generate_comments(head, base)
         pull_analysis = create_pull_analysis(pull, comments)
-        PushAnalysisComments.enqueue(pull_analysis.id)
+        PushAnalysisComments.enqueue(pull_analysis.id) unless project.silent
       rescue Analysis::Pipeline::BadGitHistory
         info { "Pull #{pull} references commits that no longer exist, skipping analysis" }
       end

--- a/spec/diggit/jobs/analyse_pull_spec.rb
+++ b/spec/diggit/jobs/analyse_pull_spec.rb
@@ -78,6 +78,23 @@ RSpec.describe(Diggit::Jobs::AnalysePull) do
         expect(pull_analysis.project_id).to eql(project.id)
         expect(pull_analysis.comments).to match(comments.as_json)
       end
+
+      it 'enqueues PushAnalysisComments job' do
+        expect(Diggit::Jobs::PushAnalysisComments).
+          to receive(:enqueue) do |pull_analysis_id|
+            expect(PullAnalysis.last.id).to equal(pull_analysis_id)
+          end
+        run!
+      end
+
+      context 'on a silent repo' do
+        let(:project) { FactoryGirl.create(:project, :diggit, silent: true) }
+
+        it 'does not enqueue PushAnalysisComments' do
+          expect(Diggit::Jobs::PushAnalysisComments).not_to receive(:enqueue)
+          run!
+        end
+      end
     end
   end
 end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :project do
     sequence(:gh_path) { |n| "lawrencejones/#{n}" }
     watch false
+    silent false
 
     trait :watched do
       watch true


### PR DESCRIPTION
Allows projects to be watched in a silent mode, preventing diggit
from sending comments to Github.