### PR TITLE
Guard for infinite complexity increase

### DIFF
--- a/lib/diggit/analysis/complexity/report.rb
+++ b/lib/diggit/analysis/complexity/report.rb
@@ -69,10 +69,11 @@ module Diggit
             base, base_complexity = complexity_history.min_by(&:last)
 
             change = (head_complexity - base_complexity) / base_complexity
+            change = 0.0 if change.infinite?
             pct_change = (100 * change).round(2)
 
             [file, [pct_change, head, base]]
-          end.reject { |k, _v| k.nil? }
+          end
         end
 
         # Filter file histories for those that have increased in complexity in this last


### PR DESCRIPTION
Was throwing error when converting Infinity to an integer.
https://rollbar.com/lawrencejones/diggit/items/53/occurrences/13131495247/

Infinity will only be found on files that had too little history,
or a point in history with zero complexity. We can assume this is
of little interest to us, and safely ignore this file.