### PR TITLE
Fix bug with complexity report deleted files

### DIFF
--- a/lib/diggit/analysis/complexity/report.rb
+++ b/lib/diggit/analysis/complexity/report.rb
@@ -23,6 +23,9 @@ module Diggit
           @repo = repo
           @base = conf.fetch(:base)
           @head = conf.fetch(:head)
+
+          @repo.checkout(head)
+          @files_in_head = repo.ls_files
         end
 
         def comments
@@ -31,7 +34,7 @@ module Diggit
 
         private
 
-        attr_reader :base, :head, :repo
+        attr_reader :base, :head, :repo, :files_in_head
 
         def generate_comments
           files_above_threshold.to_h.map do |file, (complexity_increase, head, base)|
@@ -118,6 +121,7 @@ module Diggit
         def tracked_files
           @tracked_files ||= repo.
             diff(base, head).stats[:files].keys.
+            select { |file| files_in_head.include?(file) }.
             reject { |file| IGNORED_EXTENSIONS.include?(File.extname(file)) }
         end
       end

--- a/spec/diggit/analysis/complexity/report_spec.rb
+++ b/spec/diggit/analysis/complexity/report_spec.rb
@@ -11,11 +11,14 @@ def complexity_test_repo
 
     # One week ago
     repo.write('master.rb', 'three')
+    repo.write('to_be_removed.rb', 'three')
     repo.commit('one week ago', time: Time.now.advance(days: -6))
 
     # Branch yesterday
     repo.g.branch('feature').checkout
     repo.write('master.rb', 'four')
+    # This verifies fix for https://rollbar.com/lawrencejones/diggit/items/55/
+    repo.rm('to_be_removed.rb')
     repo.commit('yesterday', time: Time.now.advance(days: -1))
   end
 end

--- a/spec/diggit/analysis/temporary_analysis_repo.rb
+++ b/spec/diggit/analysis/temporary_analysis_repo.rb
@@ -29,6 +29,10 @@ class TemporaryAnalysisRepo
     File.write(File.join(base, file), contents)
   end
 
+  def rm(file)
+    File.unlink(File.join(base, file))
+  end
+
   def commit(message, time: Time.now)
     Diggit::Services::Environment.with_temporary_env(git_time_env(time)) do
       g.add(all: true)


### PR DESCRIPTION
Complexity history was being built for deleted files, causing git
to throw a 'file not in commitish' error.
https://rollbar.com/lawrencejones/diggit/items/55/