### PR TITLE
Fix `invalid byte sequence in US-ASCII`

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     ffi (1.9.10)
-    git (1.2.9.1)
+    git (1.3.0)
     hamster (2.0.0)
       concurrent-ruby (~> 0.8)
     hanami-router (0.6.2)


### PR DESCRIPTION
Git sometimes spits out badly encoded strings, and pre-1.3.0
ruby-git didn't handle them correctly.

This led to errors like
https://rollbar.com/lawrencejones/diggit/items/60/ where the
analysis crashed from inside the git library.

Relevant discussion https://github.com/schacon/ruby-git/pull/190