### PR TITLE
Optimises RefactorDiligence

### DIFF
--- a/bin/que
+++ b/bin/que
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+bundle exec que ./config/que.rb

--- a/config/que.rb
+++ b/config/que.rb
@@ -1,0 +1,2 @@
+require_relative '../lib/diggit/system'
+Diggit::System.init

--- a/lib/diggit/analysis/complexity/report.rb
+++ b/lib/diggit/analysis/complexity/report.rb
@@ -98,7 +98,8 @@ module Diggit
         def path_complexity_history
           @path_complexity_history ||= path_changes.map do |path, changes|
             [path, changes.first(CHANGE_WINDOW).map do |commit|
-              [commit, self.class.compute_complexity(cat_file(path, commit) || '')]
+              file_content = cat_file(path: path, commit: commit) || ''
+              [commit, self.class.compute_complexity(file_content)]
             end]
           end
         end
@@ -110,7 +111,7 @@ module Diggit
         #
         def path_changes
           tracked_paths.reduce(Hamster::Hash.new) do |changes, path|
-            last_commits_of_the_day = rev_list(repo.head.target, path).
+            last_commits_of_the_day = rev_list(commit: repo.head.target, path: path).
               group_by { |commit| commit.author[:time].to_date }.
               map { |(_, commits)| commits.max_by { |c| c.author[:time] } }.
               sort_by { |commit| -commit.author[:time].to_i }

--- a/lib/diggit/analysis/refactor_diligence/method_size_history.rb
+++ b/lib/diggit/analysis/refactor_diligence/method_size_history.rb
@@ -1,74 +1,67 @@
 require 'active_support/core_ext/module'
-require_relative './commit_scanner'
+
+require_relative 'ruby_method_parser'
+require_relative '../../services/git_helpers'
 
 module Diggit
   module Analysis
     module RefactorDiligence
       class MethodSizeHistory
-        def initialize(repo)
+        include Services::GitHelpers
+
+        MAX_FILE_CHANGES = 25
+
+        def initialize(repo, head:, files:)
           @repo = repo
-          @scanner = CommitScanner.new(repo)
+          @head = head
+          @files = files
         end
 
-        attr_reader :scanner
+        attr_reader :repo, :head, :files
 
-        # Uses commit scanner to generate method statistics, then returns back a map
-        # of method name to method size.
-        #
-        #   {'method_a' => 2}
-        #
-        def scan(commit, files:)
-          scanner.scan(commit, files: files).
-            transform_values { |stats| stats.fetch(:lines) }
+        # Computes the history of all methods in all files.
+        def history
+          @history ||= files.map { |file| history_for_file(file) }.inject(:merge)
         end
 
-        # Generates method size history across commits for all methods located inside
-        # files that are present in `restrict_to`.
-        #
-        # Output is of the form...
+        private
+
+        # Generates method size history for the given file.
         #
         #   { 'method_a' => [[3, 'second-sha'], [2, 'first-sha']] }
         #
-        def history(commits, restrict_to:)
-          sizes_by_commit = history_by_commit(commits, restrict_to: restrict_to)
-          commit_sizes, initial_sha = sizes_by_commit.first
+        # rubocop:disable Metrics/AbcSize
+        def history_for_file(file)
+          commits = rev_list(commit: head, path: file).first(MAX_FILE_CHANGES)
+          file_history = commits.map { |commit| [scan(file, commit), commit] }
+          initial_sizes, initial_commit = file_history.first
 
-          # Generate history seed, map of method name to lists of tuples of [size, sha]
-          initial_history = commit_sizes.map { |k, size| [k, [[size, initial_sha]]] }
-          tracked_methods = Set[*initial_history.keys]
+          tracked_methods = Set.new(file_history.first.first.keys)
+          initial_history = initial_sizes.map do |method, size|
+            [method, [[size, initial_commit]]]
+          end
 
-          sizes_by_commit.
-            each_with_object(Hamster::Hash[initial_history]) do |(sizes, sha), history|
+          file_history.
+            each_with_object(Hamster::Hash[initial_history]) do |(sizes, commit), history|
               tracked_methods.each do |method|
                 last_size = history[method].last.first
                 current_size = sizes[method] || last_size + 1 # mark to remove
 
-                history[method] << [current_size, sha] if last_size > current_size
-                history[method].last[1] = sha          if last_size == current_size
-                tracked_methods.delete(method)         if last_size < current_size
+                history[method] << [current_size, commit] if last_size > current_size
+                history[method].last[1] = commit          if last_size == current_size
+                tracked_methods.delete(method)            if last_size < current_size
               end
             end
         end
+        # rubocop:enable Metrics/AbcSize
 
-        # Produces a timeline of method sizes for each of the given commits, in commit
-        # order, with the associated commit sha.
+        # Parses method size from the given file at the given commit.
         #
-        # Example for two commits, where `method_a` was originally 2 lines...
+        #   { 'method' => 4, ... }
         #
-        #   [
-        #     [{'method_a' => 3, 'method_b' => 4}, 'second-sha'],
-        #     [{'method_a' => 2}, 'first-sha'],
-        #   ]
-        #
-        # Only methods that were found in the original commit will be tracked, and once
-        # a method cannot be found it will cease to be tracked.
-        def history_by_commit(commits, restrict_to:)
-          commits.map { |commit| scan(commit, files: restrict_to) }.
-            each_with_object([]) do |method_sizes, history|
-              previous_sizes = history.last || Hamster::Hash.new(method_sizes)
-              tracked_methods = previous_sizes.keys.intersection(method_sizes.keys)
-              history << previous_sizes.merge(method_sizes).slice(*tracked_methods)
-            end.zip(commits)
+        def scan(file, commit)
+          RubyMethodParser.new(cat_file(commit: commit, path: file), file: file).methods.
+            transform_values { |method_info| method_info.fetch(:lines) }
         end
       end
     end

--- a/lib/diggit/analysis/refactor_diligence/report.rb
+++ b/lib/diggit/analysis/refactor_diligence/report.rb
@@ -18,7 +18,7 @@ module Diggit
         end
 
         def comments
-          @comments ||= commits_of_interest.empty? ? [] : generate_comments
+          @comments ||= ruby_files_changed.empty? ? [] : generate_comments
         end
 
         private
@@ -32,7 +32,7 @@ module Diggit
               location: method_locations.fetch(method),
               message: "`#{method}` has increased in size the last "\
                        "#{history.size} times it has been modified - "\
-                       "#{history.map(&:last).join(' ')}",
+                       "#{history.map(&:last).map(&:oid).join(' ')}",
               meta: {
                 method_name: method,
                 times_increased: history.size,
@@ -41,30 +41,33 @@ module Diggit
           end
         end
 
+        # Filters for methods that have increased in size beyond the threshold, and saw
+        # their last size increase happen in this diff.
         def methods_over_threshold
-          @methods_over_threshold ||= MethodSizeHistory.new(repo).
-            history(commits_of_interest.map(&:oid), restrict_to: ruby_files_changed).
+          @methods_over_threshold ||= method_size_history.
             select { |_, history| history.size > TIMES_INCREASED_THRESHOLD }.
-            select { |_, history| commits_in_diff.include?(history.first[1]) }
+            select { |_, history| commits_in_diff.include?(history.first[1].oid) }
         end
 
-        # Generate a list of commits that contain changes to the originally modified
-        # files.
-        def commits_of_interest
-          @commits_of_interest ||= ruby_files_changed.
-            flat_map { |ruby_file| rev_list(head, ruby_file).first(10) }.
-            uniq(&:oid).
-            sort_by { |commit| -commit.author[:time].to_i }
-        end
-
-        # Identifies the location of each method in the latest commit
+        # Parses all the ruby files changed in head to identify the location of each
+        # method in the head commit.
+        #
+        #   { 'method' => 'file.rb:4', ... }
+        #
         def method_locations
-          @method_locations ||= CommitScanner.new(repo).
-            scan(commits_of_interest.first.oid, files: ruby_files_changed).
-            transform_values { |stats| stats.fetch(:loc) }
+          @method_locations ||= ruby_files_changed.
+            map { |file| [file, cat_file(commit: head, path: file)] }.
+            map { |(file, contents)| RubyMethodParser.new(contents, file: file).methods }.
+            inject(:merge).
+            transform_values { |method_info| method_info.fetch(:loc) }
         end
 
-        # Commit shas that make up the diff
+        def method_size_history
+          @method_size_history ||= MethodSizeHistory.
+            new(repo, head: head, files: ruby_files_changed).
+            history
+        end
+
         def commits_in_diff
           @commits_in_diff ||= commits_between(base, head).map(&:oid)
         end

--- a/lib/diggit/services/git_helpers.rb
+++ b/lib/diggit/services/git_helpers.rb
@@ -12,7 +12,7 @@ module Diggit
 
       # Runs the rev-list command, returning an array of commit shas that are ancestors of
       # the given commit, filtered by path if one is supplied.
-      def rev_list(commit, path = nil)
+      def rev_list(commit:, path: nil)
         args = ['rev-list', commit.try(:oid) || commit]
         args.push('--', path) unless path.nil?
 
@@ -23,7 +23,7 @@ module Diggit
 
       # Generates the string content of the blob located at `path` in commit `commit`.
       # Returns nil if file does not exist in this commit.
-      def cat_file(path, commit)
+      def cat_file(commit:, path:)
         tree = commit.try(:tree) || repo.lookup(commit).tree
 
         blob_entry = path.split('/').reduce(tree) do |treeish, ref|

--- a/spec/diggit/analysis/refactor_diligence/method_size_history_spec.rb
+++ b/spec/diggit/analysis/refactor_diligence/method_size_history_spec.rb
@@ -1,60 +1,46 @@
 require 'diggit/analysis/refactor_diligence/method_size_history'
 
 RSpec.describe(Diggit::Analysis::RefactorDiligence::MethodSizeHistory) do
-  subject(:instance) { described_class.new(repo) }
+  subject(:instance) { described_class.new(repo, head: 'head', files: [file]) }
   let(:repo) { instance_double(Rugged::Repository) }
-
-  let(:commits) { [:third_commit, :second_commit, :first_commit] }
+  let(:file) { 'file.rb' }
 
   before do
+    allow(instance).
+      to receive(:rev_list).
+      with(path: file, commit: 'head').
+      and_return(%i(third second first))
+
     allow(instance).to receive(:scan).
-      with(:first_commit, files: anything).
+      with(file, :first).
       and_return('fetch' => 3, 'bad_idea' => 5)
 
     allow(instance).to receive(:scan).
-      with(:second_commit, files: anything).
+      with(file, :second).
       and_return('fetch' => 2, 'push' => 3)
 
     allow(instance).to receive(:scan).
-      with(:third_commit, files: anything).
+      with(file, :third).
       and_return('fetch' => 5, 'push' => 3)
   end
 
   describe '.history' do
-    subject(:history) { instance.history(commits, restrict_to: []).to_h }
+    subject(:history) { instance.history.to_h }
+
+    it 'only tracks methods present in first commit' do
+      expect(history.keys).not_to include('bad_idea')
+    end
 
     it 'stops tracking after refactor (size reduction)' do
-      expect(history['fetch'].map(&:first)).not_to include(3)
+      expect(history['fetch']).not_to include([3, :first])
     end
 
     it 'aggregates method sizes into sha-size tuples' do
-      expect(history).to include('fetch' => [[5, :third_commit], [2, :second_commit]])
+      expect(history).to include('fetch' => [[5, :third], [2, :second]])
     end
 
     it 'removes duplicate entries for same size, taking oldest sha' do
-      expect(history).to include('push' => [[3, :second_commit]])
-    end
-  end
-
-  describe '.history_by_commit' do
-    subject(:sizes) { instance.history_by_commit(commits, restrict_to: []) }
-
-    its(:count) { is_expected.to eql(commits.count) }
-
-    it 'only tracks methods present in first commit' do
-      sizes.each { |(methods)| expect(methods.keys).not_to include('bad_idea') }
-    end
-
-    it 'does not list methods beyond their creation' do
-      expect(sizes[2].first.keys).not_to include('push')
-    end
-
-    it 'tracks method sizes in reverse order' do
-      expect(sizes[0].first.to_h).to eql('fetch' => 5, 'push' => 3)
-      expect(sizes[1].first.to_h).to eql('fetch' => 2, 'push' => 3)
-      expect(sizes[2].first.to_h).to eql('fetch' => 3)
-
-      expect(sizes.map(&:second)).to eql([:third_commit, :second_commit, :first_commit])
+      expect(history).to include('push' => [[3, :second]])
     end
   end
 end

--- a/spec/diggit/analysis/refactor_diligence/report_spec.rb
+++ b/spec/diggit/analysis/refactor_diligence/report_spec.rb
@@ -5,8 +5,12 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::Report) do
   subject(:report) { described_class.new(repo, base: base, head: head) }
   let(:repo) { refactor_diligence_test_repo }
 
-  let(:head) { repo.branches.find { |b| b.name == 'feature' }.target.oid }
-  let(:base) { repo.branches.find { |b| b.name == 'master' }.target.oid }
+  def branch_oid(branch)
+    repo.branches.find { |b| b.name == branch }.target.oid
+  end
+
+  let(:head) { branch_oid('feature') }
+  let(:base) { branch_oid('master') }
 
   before { stub_const("#{described_class}::TIMES_INCREASED_THRESHOLD", threshold) }
   let(:threshold) { 2 }
@@ -21,8 +25,8 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::Report) do
     let(:master_comment) { comment_for(/Master::initialize/) }
 
     context 'when pull does not change ruby files' do
-      let(:head) { 'non-ruby' }
-      let(:base) { 'feature' }
+      let(:head) { branch_oid('non-ruby') }
+      let(:base) { branch_oid('feature') }
 
       it { is_expected.to eql([]) }
     end
@@ -45,6 +49,7 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::Report) do
 
     it 'tags commit shas in comment' do
       shas_in_comment = socket_comment[:message].scan(/\S{40}/)
+      expect(shas_in_comment.size).to be(3)
       shas_in_comment.each { |sha| expect(repo.exists?(sha)).to be(true) }
     end
 

--- a/spec/diggit/services/git_helpers_spec.rb
+++ b/spec/diggit/services/git_helpers_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe(Diggit::Services::GitHelpers) do
   end
 
   describe '.rev_list' do
-    subject(:log) { helpers.rev_list(commit, path) }
+    subject(:log) { helpers.rev_list(commit: commit, path: path) }
     let(:commit) { repo.last_commit.oid }
 
     context 'without path' do
@@ -50,13 +50,13 @@ RSpec.describe(Diggit::Services::GitHelpers) do
 
     context 'for file that exists' do
       it 'returns string contents' do
-        expect(helpers.cat_file('README.md', commit)).to eql('content')
+        expect(helpers.cat_file(path: 'README.md', commit: commit)).to eql('content')
       end
     end
 
     context 'for file that does not exist' do
       it 'returns nil' do
-        expect(helpers.cat_file('not_here', commit)).to be_nil
+        expect(helpers.cat_file(path: 'not_here', commit: commit)).to be_nil
       end
     end
   end


### PR DESCRIPTION
Changes from dealing with a working tree, and scanning every file
for each suspected change commit to scanning only specific files
in the commits that changed them.