### PR TITLE
Fix transient file errors

### DIFF
--- a/.pryrc
+++ b/.pryrc
@@ -8,7 +8,7 @@ Pry.config.prompt = [proc { 'diggit> ' }]
 require './lib/diggit/system'
 Diggit::System.init
 
-Que.mode = :sync
+Que.mode = :off
 Que.logger = Logger.new(STDOUT)
 Que.logger.level = Logger::INFO.to_i
 

--- a/lib/diggit/jobs/poll_github.rb
+++ b/lib/diggit/jobs/poll_github.rb
@@ -54,7 +54,7 @@ module Diggit
       def pull_analysis_exists?(pull)
         PullAnalysis.
           joins(:project).
-          where('projects.gh_path' => pull[:head][:repo][:full_name]).
+          where('projects.gh_path' => pull[:base][:repo][:full_name]).
           exists?(pull: pull[:number],
                   head: pull[:head][:sha],
                   base: pull[:base][:sha])

--- a/lib/diggit/services/git_helpers.rb
+++ b/lib/diggit/services/git_helpers.rb
@@ -13,7 +13,7 @@ module Diggit
       # Runs the rev-list command, returning an array of commit shas that are ancestors of
       # the given commit, filtered by path if one is supplied.
       def rev_list(commit:, path: nil)
-        args = ['rev-list', commit.try(:oid) || commit]
+        args = ['rev-list', '--remove-empty', commit.try(:oid) || commit]
         args.push('--', path) unless path.nil?
 
         command(*args).split.map do |commit_sha|

--- a/spec/diggit/services/git_helpers_spec.rb
+++ b/spec/diggit/services/git_helpers_spec.rb
@@ -14,12 +14,15 @@ RSpec.describe(Diggit::Services::GitHelpers) do
   let(:repo) do
     TemporaryAnalysisRepo.create do |repo|
       repo.write('README.md', 'content')
+      repo.write('transient', 'hey there')
       repo.commit('1')
 
       repo.write('another_file', 'content')
+      repo.rm('transient')
       repo.commit('2')
 
       repo.write('README.md', 'more content')
+      repo.write('transient', 'hey again')
       repo.commit('3')
     end
   end
@@ -41,6 +44,14 @@ RSpec.describe(Diggit::Services::GitHelpers) do
 
       it 'lists Rugged::Commits that modified the given path' do
         expect(log.map(&:message)).to eql(%w(3 1))
+      end
+
+      context 'when path is transient' do
+        let(:path) { 'transient' }
+
+        it 'stops at deletion revision' do
+          expect(log.size).to be(1)
+        end
       end
     end
   end


### PR DESCRIPTION
Stop the rev_list at a file deletion to avoid attempting to parse
a nil file contents value.