### PR TITLE
Per project gh tokens

### DIFF
--- a/db/migrate/20160511153341_add_gh_token_to_projects.rb
+++ b/db/migrate/20160511153341_add_gh_token_to_projects.rb
@@ -1,0 +1,6 @@
+class AddGhTokenToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :encrypted_gh_token, :binary
+    add_column :projects, :gh_token_initialization_vector, :binary
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,19 +11,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160506173240) do
+ActiveRecord::Schema.define(version: 20160511153341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "projects", force: :cascade do |t|
-    t.string  "gh_path",                   limit: 126,                 null: false
-    t.boolean "watch",                                 default: true
+    t.string  "gh_path",                        limit: 126,                 null: false
+    t.boolean "watch",                                      default: true
     t.text    "ssh_public_key"
     t.binary  "encrypted_ssh_private_key"
     t.binary  "ssh_initialization_vector"
-    t.boolean "polled",                                default: false, null: false
-    t.boolean "silent",                                default: false, null: false
+    t.boolean "polled",                                     default: false, null: false
+    t.boolean "silent",                                     default: false, null: false
+    t.binary  "encrypted_gh_token"
+    t.binary  "gh_token_initialization_vector"
   end
 
   add_index "projects", ["gh_path"], name: "index_projects_on_gh_path", unique: true, using: :btree

--- a/lib/diggit/github/client.rb
+++ b/lib/diggit/github/client.rb
@@ -3,13 +3,20 @@ require_relative '../../../config/prius'
 
 module Diggit
   module Github
-    # Authenticated github client as diggit-bot
+    # Authenticated Github client as diggit-bot
     def self.client
       @client ||= Octokit::Client.new(access_token: Prius.get(:diggit_github_token))
     end
 
+    # Ideally diggit-bot
     def self.login
       @login ||= client.user[:login]
+    end
+
+    # Returns the appropriate Github client for the given project
+    def self.client_for(project)
+      return Github.client if project.gh_token.nil?
+      Octokit::Client.new(access_token: project.gh_token)
     end
   end
 end

--- a/lib/diggit/jobs/poll_github.rb
+++ b/lib/diggit/jobs/poll_github.rb
@@ -37,7 +37,7 @@ module Diggit
 
       def poll(project)
         info { "[#{project.gh_path}] Polling for new PRs..." }
-        Github.client.pulls(project.gh_path).
+        Github.client_for(project).pulls(project.gh_path).
           reject { |pull| pull_analysis_exists?(pull) }.
           each   { |pull| queue_analysis(pull, project) }
       end

--- a/lib/diggit/models/project.rb
+++ b/lib/diggit/models/project.rb
@@ -11,21 +11,13 @@ class Project < ActiveRecord::Base
     end
   end
 
-  def owner
-    gh_path.split('/').first
-  end
-
-  def repo
-    gh_path.split('/').last
-  end
+  extend Diggit::Services::Secure::ActiveRecordHelpers
+  encrypted_field :ssh_private_key, iv: :ssh_initialization_vector
+  encrypted_field :gh_token, iv: :gh_token_initialization_vector
 
   def keys?
     ssh_public_key.present? && encrypted_ssh_private_key.present?
   end
-
-  extend Diggit::Services::Secure::ActiveRecordHelpers
-  encrypted_field :ssh_private_key, iv: :ssh_initialization_vector
-  encrypted_field :gh_token, iv: :gh_token_initialization_vector
 
   def generate_keypair!
     key = SSHKey.generate(type: 'RSA', bits: 2048)

--- a/lib/diggit/models/project.rb
+++ b/lib/diggit/models/project.rb
@@ -23,18 +23,9 @@ class Project < ActiveRecord::Base
     ssh_public_key.present? && encrypted_ssh_private_key.present?
   end
 
-  def ssh_private_key
-    return nil unless keys?
-    Diggit::Services::Secure.
-      decode(encrypted_ssh_private_key, ssh_initialization_vector)
-  end
-
-  def ssh_private_key=(private_key)
-    encrypted_key, initialization_vector = Diggit::Services::Secure.
-      encode(private_key)
-    self.encrypted_ssh_private_key = encrypted_key
-    self.ssh_initialization_vector = initialization_vector
-  end
+  extend Diggit::Services::Secure::ActiveRecordHelpers
+  encrypted_field :ssh_private_key, iv: :ssh_initialization_vector
+  encrypted_field :gh_token, iv: :gh_token_initialization_vector
 
   def generate_keypair!
     key = SSHKey.generate(type: 'RSA', bits: 2048)

--- a/lib/diggit/services/secure.rb
+++ b/lib/diggit/services/secure.rb
@@ -3,6 +3,23 @@ require 'digest'
 module Diggit
   module Services
     module Secure
+      module ActiveRecordHelpers
+        def encrypted_field(field, iv:)
+          define_method(field) do
+            encrypted_payload = send(:"encrypted_#{field}")
+            return nil if encrypted_payload.nil?
+
+            Secure.decode(encrypted_payload, send(iv))
+          end
+
+          define_method(:"#{field}=") do |value|
+            encrypted, initialization_vector = Secure.encode(value)
+            send(:"encrypted_#{field}=", encrypted)
+            send(:"#{iv}=", initialization_vector)
+          end
+        end
+      end
+
       def self.secret=(value)
         @secret = Digest::SHA2.digest(value)
       end

--- a/lib/tasks/one_off.rb
+++ b/lib/tasks/one_off.rb
@@ -20,17 +20,4 @@ namespace :one_off do
     puts('Add the following public key to Github account with access to this repo:')
     puts("\n#{project.ssh_public_key}\n")
   end
-
-  desc 'Backfills projects to use diggit-bot github token'
-  task :backfill_projects_gh_token do
-    puts("Backfilling #{Project.count} projects...")
-    ActiveRecord::Base.transaction do
-      Project.all.each do |project|
-        puts("- #{project.gh_path}")
-        project.gh_token = Prius.get(:diggit_github_token)
-        project.save!
-      end
-    end
-    puts('Done!')
-  end
 end

--- a/lib/tasks/one_off.rb
+++ b/lib/tasks/one_off.rb
@@ -20,4 +20,17 @@ namespace :one_off do
     puts('Add the following public key to Github account with access to this repo:')
     puts("\n#{project.ssh_public_key}\n")
   end
+
+  desc 'Backfills projects to use diggit-bot github token'
+  task :backfill_projects_gh_token do
+    puts("Backfilling #{Project.count} projects...")
+    ActiveRecord::Base.transaction do
+      Project.all.each do |project|
+        puts("- #{project.gh_path}")
+        project.gh_token = Prius.get(:diggit_github_token)
+        project.save!
+      end
+    end
+    puts('Done!')
+  end
 end

--- a/spec/diggit/github/client_spec.rb
+++ b/spec/diggit/github/client_spec.rb
@@ -1,0 +1,27 @@
+require 'diggit/github/client'
+
+RSpec.describe(Diggit::Github) do
+  let(:github) { described_class }
+
+  describe '.client_for' do
+    context 'project without gh_token' do
+      let(:project) { FactoryGirl.create(:project) }
+
+      it 'gives Diggit::Github.client' do
+        expect(github.client_for(project)).to be(Diggit::Github.client)
+      end
+    end
+
+    context 'project with gh_token' do
+      let(:project) { FactoryGirl.create(:project, :gh_token) }
+
+      it 'initialises new client with token' do
+        expect(Octokit::Client).
+          to receive(:new).
+          with(access_token: project.gh_token).
+          and_call_original
+        expect(github.client_for(project)).to be_instance_of(Octokit::Client)
+      end
+    end
+  end
+end

--- a/spec/diggit/jobs/poll_github_spec.rb
+++ b/spec/diggit/jobs/poll_github_spec.rb
@@ -28,6 +28,9 @@ RSpec.describe(Diggit::Jobs::PollGithub) do
   describe '.run' do
     let(:head) { 'head-sha' }
     before do
+      allow(Diggit::Github).
+        to receive(:gh_client_for).
+        with(anything).and_return(gh_client)
       allow(gh_client).
         to receive(:pulls).
         with(payments_service.gh_path).

--- a/spec/diggit/models/project_spec.rb
+++ b/spec/diggit/models/project_spec.rb
@@ -7,9 +7,6 @@ RSpec.describe(Project) do
       ssh_public_key: 'ssh-public-key', ssh_private_key: 'ssh-private-key' }
   end
 
-  its(:owner) { is_expected.to eql('lawrencejones') }
-  its(:repo) { is_expected.to eql('diggit') }
-
   it { is_expected.to be_valid }
   it { is_expected.to validate_presence_of(:gh_path) }
   it { is_expected.not_to allow_value('lawrencejones').for(:gh_path) }

--- a/spec/diggit/services/secure_spec.rb
+++ b/spec/diggit/services/secure_spec.rb
@@ -8,4 +8,29 @@ RSpec.describe(Diggit::Services::Secure) do
     encrypted, iv = described_class.encode(data)
     expect(described_class.decode(encrypted, iv)).to eql(data)
   end
+
+  describe 'ActiveRecordHelpers' do
+    class DummyModel
+      attr_accessor :encrypted_token, :token_iv
+      extend Diggit::Services::Secure::ActiveRecordHelpers
+      encrypted_field :token, iv: :token_iv
+    end
+    subject(:model) { DummyModel.new }
+
+    describe '.encrypted_field' do
+      it 'sets both ciphertext and iv on set' do
+        expect(model.encrypted_token).to be_nil
+        expect(model.token_iv).to be_nil
+
+        model.token = 'hello'
+        expect(model.encrypted_token).not_to be_nil
+        expect(model.token_iv).not_to be_nil
+      end
+
+      it 'returns decoded values on get' do
+        model.token = 'hello'
+        expect(model.token).to eql('hello')
+      end
+    end
+  end
 end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -13,6 +13,10 @@ FactoryGirl.define do
       ssh_private_key 'ssh-private-key'
     end
 
+    trait :gh_token do
+      gh_token 'github-token'
+    end
+
     trait :diggit do
       watched
       gh_path 'lawrencejones/diggit'


### PR DESCRIPTION
Adds a `gh_token` field to `Project`, allowing creation of appropriate clients for each project when talking to Github. This will allow, for example, polling of private repos where access has been granted to an access key that is distinct from `diggit-bot`s.