### PR TITLE
Fixes ssh auth bug when supplied publickey

### DIFF
--- a/lib/diggit/services/project_cloner.rb
+++ b/lib/diggit/services/project_cloner.rb
@@ -49,7 +49,7 @@ module Diggit
       def fetch
         credentials.with_keyfiles do |keyfiles|
           ssh_creds = Rugged::Credentials::SshKey.
-            new(keyfiles.merge(username: 'git'))
+            new(keyfiles.slice(:privatekey).merge(username: 'git'))
           info { "[#{project.gh_path}] Fetching origin..." }
           repo.fetch('origin', credentials: ssh_creds)
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,6 +67,8 @@ RSpec.configure do |config|
   config.order = :random
   Kernel.srand(config.seed)
 
+  config.filter_run_excluding integration: true unless ENV['INTEG']
+
   config.include(Shoulda::Matchers::ActiveModel)
   config.include(Shoulda::Matchers::ActiveRecord)
 


### PR DESCRIPTION
libssh2 will fail to authenticate if given both the private and
public key (yay!).