### PR TITLE
Fix ssh auth take 2!

### DIFF
--- a/lib/diggit/models/project.rb
+++ b/lib/diggit/models/project.rb
@@ -20,7 +20,7 @@ class Project < ActiveRecord::Base
   end
 
   def generate_keypair!
-    key = SSHKey.generate(type: 'RSA', bits: 2048)
+    key = SSHKey.generate(type: 'RSA', bits: 2048, comment: 'bot@diggit-repo.com')
     self.ssh_public_key = key.ssh_public_key
     self.ssh_private_key = key.private_key
     save!

--- a/lib/diggit/services/project_cloner.rb
+++ b/lib/diggit/services/project_cloner.rb
@@ -49,7 +49,7 @@ module Diggit
       def fetch
         credentials.with_keyfiles do |keyfiles|
           ssh_creds = Rugged::Credentials::SshKey.
-            new(keyfiles.slice(:privatekey).merge(username: 'git'))
+            new(keyfiles.merge(username: 'git'))
           info { "[#{project.gh_path}] Fetching origin..." }
           repo.fetch('origin', credentials: ssh_creds)
         end

--- a/spec/diggit/services/project_cloner_spec.rb
+++ b/spec/diggit/services/project_cloner_spec.rb
@@ -45,14 +45,6 @@ RSpec.describe(Diggit::Services::ProjectCloner) do
       cloner.clone { |repo| repo }
     end
 
-    # This will cause libssh2 to fail the authentication
-    it 'creates ssh credentials without the publickey' do
-      expect(Rugged::Credentials::SshKey).to receive(:new) do |conf|
-        expect(conf).not_to include(:publickey)
-      end
-      cloner.clone { |repo| repo }
-    end
-
     it 'yields with instance of Rugged::Repo' do
       expect { |b| cloner.clone(&b) }.
         to yield_with_args(instance_of(Rugged::Repository))


### PR DESCRIPTION
The previous faux-fix removed the publickey from the fields used
to initialize an Rugged::Credentials::SshKey, which worked on my
local machine as my libgcrypt can determine publickeys from
privatekeys.

Ubuntu on prod libgcrypt does not have this functionality, which
raised exceptions. Having now tried to find the workaround, it
looks like libssh2 hangs on public keys that don't have the comment.

`Project.generate_keypair!` never generated comments, and as a
result the keys would fail when passed to Rugged.