### PR TITLE
Skip diffs with >25 files changed

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -16,6 +16,9 @@ MethodLength:
 Metrics/AbcSize:
   Max: 25
 
+Style/BlockDelimiters:
+  Enabled: false
+
 Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma
 

--- a/lib/diggit/jobs/push_analysis_comments.rb
+++ b/lib/diggit/jobs/push_analysis_comments.rb
@@ -9,6 +9,8 @@ require_relative '../github/client'
 module Diggit
   module Jobs
     class PushAnalysisComments < Que::Job
+      # For reporters that are in trial mode
+      SILENT_REPORTERS = %w(Complexity).freeze
       include InstanceLogger
 
       def run(pull_analysis_id)
@@ -42,9 +44,9 @@ module Diggit
       end
 
       def pending_comments
-        @pending_comments ||= pull_analysis.comments.reject do |comment|
-          existing_comments.include?(comment.slice('report', 'index'))
-        end
+        @pending_comments ||= pull_analysis.comments.
+          reject { |c| SILENT_REPORTERS.include?(c['report']) }.
+          reject { |c| existing_comments.include?(c.slice('report', 'index')) }
       end
 
       def existing_comments

--- a/spec/diggit/analysis/refactor_diligence/test_repo.rb
+++ b/spec/diggit/analysis/refactor_diligence/test_repo.rb
@@ -1,81 +1,88 @@
 require_relative '../temporary_analysis_repo'
 
-# rubocop:disable Metrics/MethodLength, Style/AlignParameters
+# rubocop:disable Metrics/MethodLength
 def refactor_diligence_test_repo
   TemporaryAnalysisRepo.create do |repo|
-    repo.write('master.rb',
-    %(class Master
-        def initialize
-        end
-      end))
+    repo.write 'master.rb', <<-RUBY
+    class Master
+      def initialize
+      end
+    end
+    RUBY
     repo.commit('initial Master::initialize')
 
-    repo.write('master.rb',
-    %(class Master
-        def initialize
-          puts('first line')
-        end
-      end))
+    repo.write 'master.rb', <<-RUBY
+    class Master
+      def initialize
+        puts('first line')
+      end
+    end
+    RUBY
     repo.commit('Master::initialize +1')
 
-    repo.write('master.rb',
-    %(class Master
-        def initialize
-          puts('first line')
-          puts('second line')
-        end
-      end))
+    repo.write 'master.rb', <<-RUBY
+    class Master
+      def initialize
+        puts('first line')
+        puts('second line')
+      end
+    end
+    RUBY
     repo.commit('Master::initialize +2')
 
     # Start feature branch here
     repo.branch('feature')
 
-    repo.write('file.rb',
-    %(module Utils
-        class Socket
-          def initialize(host)
-            @host = host
-          end
+    repo.write 'file.rb', <<-RUBY
+    module Utils
+      class Socket
+        def initialize(host)
+          @host = host
         end
-      end))
+      end
+    end
+    RUBY
     repo.commit('initial Utils::Socket')
 
-    repo.write('file.rb',
-    %(module Utils
-        class Socket
-          def initialize(host, port)
-            @host = host
-            @port = port
-          end
+    repo.write 'file.rb', <<-RUBY
+    module Utils
+      class Socket
+        def initialize(host, port)
+          @host = host
+          @port = port
         end
-      end))
+      end
+    end
+    RUBY
     repo.commit('add port')
 
-    repo.write('file.rb',
-    %(module Utils
-        class Socket
-          def self.from_uri(uri)
-            host, port = URI.parse(uri)
-            new(host, port)
-          end
-
-          def initialize(host, port)
-            @host = host
-            @port = port
-            puts("Created new socket on \#{host}:\#{port}")
-          end
-        end
-      end))
-    repo.write('master.rb',
-    %(class Master
-        def initialize
-          puts('first line')
-          puts('second line')
+    repo.write 'file.rb', <<-RUBY
+    module Utils
+      class Socket
+        def self.from_uri(uri)
+          host, port = URI.parse(uri)
+          new(host, port)
         end
 
-        def add_a_method
+        def initialize(host, port)
+          @host = host
+          @port = port
+          puts("Created new socket on \#{host}:\#{port}")
         end
-      end))
+      end
+    end
+    RUBY
+    repo.write 'master.rb', <<-RUBY
+    class Master
+      def initialize
+        puts('first line')
+        puts('second line')
+      end
+
+      def add_a_method
+      end
+    end
+    RUBY
     repo.commit('.from_uri and log')
 
     # Start non-ruby branch here


### PR DESCRIPTION
Also restarts processing complexity, but adds it to SILENT_REPORTERS
where the comments it produces won't be pushed to github.