### PR TITLE
Removes queuing analysis from transaction in PollGithub

### DIFF
--- a/lib/diggit/jobs/poll_github.rb
+++ b/lib/diggit/jobs/poll_github.rb
@@ -29,10 +29,8 @@ module Diggit
           return destroy
         end
 
-        ActiveRecord::Base.transaction do
-          polled_projects.each { |project| poll(project) }
-          destroy
-        end
+        polled_projects.each { |project| poll(project) }
+        destroy
       end
 
       def poll(project)


### PR DESCRIPTION
The transaction was causing the enqueuing of pull analyses to be invisible to any other poll github jobs.