### PR TITLE
Prevent double queuing of repeat jobs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,15 @@ AllCops:
     - 'db/schema.rb'
     - 'vendor/bundle/**/*'
 
+Rails:
+  Enabled: true
+
+Rails/Output:
+  Enabled: false
+
+Rails/Date:
+  Enabled: false
+
 LineLength:
   Max: 90
 

--- a/lib/diggit/jobs/analyse_pull.rb
+++ b/lib/diggit/jobs/analyse_pull.rb
@@ -67,8 +67,8 @@ module Diggit
       end
 
       def time_pipeline
-        started_at = Time.now
-        yield.tap { @pipeline_duration = Time.now - started_at }
+        started_at = Time.zone.now
+        yield.tap { @pipeline_duration = Time.zone.now - started_at }
       end
 
       def create_pull_analysis(pull, comments)

--- a/lib/diggit/jobs/cron_job.rb
+++ b/lib/diggit/jobs/cron_job.rb
@@ -21,7 +21,7 @@ module Diggit
       # tomorrow.
       def self.schedule_times
         times = self::SCHEDULE_AT.map do |time_string|
-          Time.parse(time_string)
+          Time.zone.parse(time_string)
         end.sort
         times.push(*times.first(2).map { |t| t.advance(days: 1) })
         times
@@ -36,8 +36,8 @@ module Diggit
       def _run
         args = attrs[:args].first
 
-        @start_at = Time.at(args.delete('start_at'))
-        @end_at = Time.at(args.delete('end_at'))
+        @start_at = Time.zone.at(args.delete('start_at'))
+        @end_at = Time.zone.at(args.delete('end_at'))
         @time_range = @start_at...@end_at
 
         attrs[:args].shift if args.empty?

--- a/lib/diggit/routes/auth.rb
+++ b/lib/diggit/routes/auth.rb
@@ -28,7 +28,7 @@ module Diggit
         end
 
         def create_state
-          Services::Jwt.encode('github', Time.now.advance(minutes: STATE_EXPIRATION))
+          Services::Jwt.encode('github', Time.zone.now.advance(minutes: STATE_EXPIRATION))
         end
       end
 
@@ -41,7 +41,7 @@ module Diggit
 
           access_token = Services::Jwt.
             encode({ gh_token: gh_token },
-                   Time.now.advance(minutes: TOKEN_EXPIRATION))
+                   Time.zone.now.advance(minutes: TOKEN_EXPIRATION))
 
           [200, {}, [{ access_token: { token: access_token } }.to_json]]
         end

--- a/lib/diggit/system.rb
+++ b/lib/diggit/system.rb
@@ -24,6 +24,7 @@ module Diggit
 
     def self.init
       @config ||= begin
+        configure_timezone!
         configure_i18n!
         configure_rollbar!
         configure_active_record!
@@ -53,6 +54,10 @@ module Diggit
           webhook_endpoint: Prius.get(:diggit_webhook_endpoint)
         )
       end
+    end
+
+    def self.configure_timezone!
+      Time.zone = 'UTC'
     end
 
     def self.configure_i18n!

--- a/spec/diggit/analysis/complexity/report_spec.rb
+++ b/spec/diggit/analysis/complexity/report_spec.rb
@@ -4,22 +4,22 @@ def complexity_test_repo
   TemporaryAnalysisRepo.create do |repo|
     # Two weeks ago
     repo.write('master.rb', 'one')
-    repo.commit('initial', time: Time.now.advance(days: -13))
+    repo.commit('initial', time: Time.zone.now.advance(days: -13))
 
     repo.write('master.rb', 'two')
-    repo.commit('same day', time: Time.now.advance(days: -13))
+    repo.commit('same day', time: Time.zone.now.advance(days: -13))
 
     # One week ago
     repo.write('master.rb', 'three')
     repo.write('to_be_removed.rb', 'three')
-    repo.commit('one week ago', time: Time.now.advance(days: -6))
+    repo.commit('one week ago', time: Time.zone.now.advance(days: -6))
 
     # Branch yesterday
     repo.branch('feature')
     repo.write('master.rb', 'four')
     # This verifies fix for https://rollbar.com/lawrencejones/diggit/items/55/
     repo.rm('to_be_removed.rb')
-    repo.commit('yesterday', time: Time.now.advance(days: -1))
+    repo.commit('yesterday', time: Time.zone.now.advance(days: -1))
   end
 end
 

--- a/spec/diggit/analysis/pipeline_spec.rb
+++ b/spec/diggit/analysis/pipeline_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe(Diggit::Analysis::Pipeline) do
                      oid: Rugged::Blob.from_workdir(repo, 'new_file'))
       commit_tree = repo.index.write_tree
       repo.index.write
-      person = { email: 'e', name: 'n', time: Time.now }
+      person = { email: 'e', name: 'n', time: Time.zone.now.to_time }
       Rugged::Commit.create(repo, message: 'a new commit', tree: commit_tree,
                                   author: person, committer: person,
                                   parents: [repo.head.target].compact, update_ref: 'HEAD')

--- a/spec/diggit/analysis/temporary_analysis_repo.rb
+++ b/spec/diggit/analysis/temporary_analysis_repo.rb
@@ -43,11 +43,11 @@ class TemporaryAnalysisRepo
     end
   end
 
-  def commit(message, time: Time.now)
+  def commit(message, time: Time.zone.now)
     commit_tree = repo.index.write_tree(repo)
     repo.index.write
 
-    person = { email: 'git@test.com', name: 'Test', time: time }
+    person = { email: 'git@test.com', name: 'Test', time: time.to_time }
     Rugged::Commit.
       create(repo,
              message: message,

--- a/spec/diggit/jobs/cron_job_spec.rb
+++ b/spec/diggit/jobs/cron_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe(Diggit::Jobs::CronJob) do
     let(:end_at) { start_end[1] }
 
     context 'when next period is today' do
-      let(:stubbed_now) { Time.parse('10:30') }
+      let(:stubbed_now) { Time.zone.parse('10:30') }
 
       it 'returns start and end of next period' do
         expect(start_at.to_date).to eql(stubbed_now.to_date)
@@ -30,7 +30,7 @@ RSpec.describe(Diggit::Jobs::CronJob) do
     end
 
     context 'when next end is tomorrow' do
-      let(:stubbed_now) { Time.parse('11:30') }
+      let(:stubbed_now) { Time.zone.parse('11:30') }
 
       it 'computes end_at to be tomorrow' do
         expect(start_at.to_date).to eql(stubbed_now.to_date)
@@ -42,7 +42,7 @@ RSpec.describe(Diggit::Jobs::CronJob) do
     end
 
     context 'when next period is tomorrow' do
-      let(:stubbed_now) { Time.parse('13:00') }
+      let(:stubbed_now) { Time.zone.parse('13:00') }
 
       it 'computes start and end to be tomorrow' do
         expect(start_at.to_date).to eql(tomorrow.to_date)

--- a/spec/diggit/jobs/daily_analysis_summary_spec.rb
+++ b/spec/diggit/jobs/daily_analysis_summary_spec.rb
@@ -4,7 +4,7 @@ require 'diggit/jobs/daily_analysis_summary'
 RSpec.describe(Diggit::Jobs::DailyAnalysisSummary) do
   subject(:job) { described_class.new({}) }
 
-  before { allow(job).to receive(:start_at).and_return(Time.now.advance(hours: 6)) }
+  before { allow(job).to receive(:start_at).and_return(Time.zone.now.advance(hours: 6)) }
 
   describe '.render' do
     subject(:html) { job.send(:render) }
@@ -21,7 +21,7 @@ RSpec.describe(Diggit::Jobs::DailyAnalysisSummary) do
     end
     let!(:old_analysis) do
       FactoryGirl.create(:pull_analysis, project: project_old,
-                                         created_at: Time.now.advance(days: -1))
+                                         created_at: Time.zone.now.advance(days: -1))
     end
 
     let(:project_links) { dom.css('a.project') }

--- a/spec/diggit/jobs/repeat_job_spec.rb
+++ b/spec/diggit/jobs/repeat_job_spec.rb
@@ -1,0 +1,43 @@
+require 'diggit/jobs/repeat_job'
+
+RSpec.describe(Diggit::Jobs::RepeatJob) do
+  subject(:job) { described_class.new({}) }
+  let(:job_class) { described_class.to_s }
+
+  def job_counts
+    Que.job_stats.map { |stat| stat.values_at('job_class', 'count') }.to_h
+  end
+
+  describe '.run' do
+    context 'without job already queued' do
+      it 'reenqueues the job for INTERVAL seconds after current time' do
+        job._run
+        expect(job_counts[job_class]).to equal(1)
+
+        run_ats = Que.execute(<<-SQL)
+        SELECT run_at
+          FROM que_jobs
+         WHERE job_class='#{job_class}';
+        SQL
+
+        now = job.now
+        expected_next_run_at = now.advance(seconds: described_class::INTERVAL)
+        next_run_at = Time.zone.parse(run_ats.first['run_at'])
+
+        expect(next_run_at.to_i).
+          to be_within(1).
+          of(expected_next_run_at.to_i)
+      end
+    end
+
+    context 'when there is job already queued' do
+      before { described_class.enqueue }
+
+      it 'does not reenqueue job' do
+        initial_count = job_counts[job_class]
+        job._run
+        expect(job_counts[job_class]).to equal(initial_count)
+      end
+    end
+  end
+end

--- a/spec/diggit/middleware/authorize_spec.rb
+++ b/spec/diggit/middleware/authorize_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe(Diggit::Middleware::Authorize) do
   let(:auth_header) { "Bearer #{auth_token}" }
   let(:next_middleware) { null_middleware }
 
-  let(:token_expiry) { Time.now.advance(minutes: 10) }
+  let(:token_expiry) { Time.zone.now.advance(minutes: 10) }
 
   let(:auth_token) { Diggit::Services::Jwt.encode(auth_token_data, token_expiry) }
   let(:auth_token_data) { load_json_fixture('api/auth/access_token.create.fixture.json') }
@@ -34,7 +34,7 @@ RSpec.describe(Diggit::Middleware::Authorize) do
   end
 
   context 'with expired header' do
-    let(:token_expiry) { Time.now.advance(minutes: -10) }
+    let(:token_expiry) { Time.zone.now.advance(minutes: -10) }
 
     it { is_expected.to respond_with_status(401) }
     it { is_expected.to respond_with_body_that_matches(/expired_authorization_header/) }

--- a/spec/diggit/routes/auth_spec.rb
+++ b/spec/diggit/routes/auth_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe(Diggit::Routes::Auth) do
     it 'encodes state param that expires STATE_EXPIRATION minutes later' do
       state = query_params.fetch('state')
       expect { Diggit::Services::Jwt.decode(state) }.not_to raise_error
-      Timecop.travel(Time.now.advance(minutes: state_expiration + 1)) do
+      Timecop.travel(Time.zone.now.advance(minutes: state_expiration + 1)) do
         expect { Diggit::Services::Jwt.decode(state) }.
           to raise_error(JWT::ExpiredSignature)
       end

--- a/spec/diggit/services/jwt_spec.rb
+++ b/spec/diggit/services/jwt_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe(Diggit::Services::Jwt) do
   let(:data) { { 'hello' => 'world' } }
 
   it 'decode(encode(data)) == data' do
-    cipher = described_class.encode(data, Time.now.advance(minutes: 10))
+    cipher = described_class.encode(data, Time.zone.now.advance(minutes: 10))
     expect(described_class.decode(cipher)['data']).to eql(data)
   end
 end


### PR DESCRIPTION
Enforces use of Time.zone for all time based operations, to avoid
timezone confusion when parsing time values.