### PR TITLE
Fix time zones!

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,10 +7,8 @@ AllCops:
     - 'db/schema.rb'
     - 'vendor/bundle/**/*'
 
-Rails/Date:
+Rails:
   Enabled: true
-  Exclude:
-    - 'lib/diggit/jobs/**/*'
 
 Rails/Output:
   Enabled: false

--- a/lib/diggit/jobs/analyse_pull.rb
+++ b/lib/diggit/jobs/analyse_pull.rb
@@ -67,8 +67,8 @@ module Diggit
       end
 
       def time_pipeline
-        started_at = Time.now
-        yield.tap { @pipeline_duration = Time.now - started_at }
+        started_at = Time.zone.now
+        yield.tap { @pipeline_duration = Time.zone.now - started_at }
       end
 
       def create_pull_analysis(pull, comments)

--- a/lib/diggit/jobs/cron_job.rb
+++ b/lib/diggit/jobs/cron_job.rb
@@ -21,7 +21,7 @@ module Diggit
       # tomorrow.
       def self.schedule_times
         times = self::SCHEDULE_AT.map do |time_string|
-          Time.parse(time_string)
+          Time.zone.parse(time_string)
         end.sort
         times.push(*times.first(2).map { |t| t.advance(days: 1) })
         times
@@ -36,8 +36,8 @@ module Diggit
       def _run
         args = attrs[:args].first
 
-        @start_at = Time.at(args.delete('start_at'))
-        @end_at = Time.at(args.delete('end_at'))
+        @start_at = Time.zone.at(args.delete('start_at'))
+        @end_at = Time.zone.at(args.delete('end_at'))
         @time_range = @start_at...@end_at
 
         attrs[:args].shift if args.empty?

--- a/lib/diggit/system.rb
+++ b/lib/diggit/system.rb
@@ -58,7 +58,8 @@ module Diggit
     end
 
     def self.configure_timezone!
-      Time.zone = 'UTC'
+      Time.zone = 'Europe/London'
+      Time.zone_default = Time.zone
     end
 
     def self.configure_i18n!

--- a/spec/diggit/analysis/pipeline_spec.rb
+++ b/spec/diggit/analysis/pipeline_spec.rb
@@ -59,7 +59,9 @@ RSpec.describe(Diggit::Analysis::Pipeline) do
                      oid: Rugged::Blob.from_workdir(repo, 'new_file'))
       commit_tree = repo.index.write_tree
       repo.index.write
+      # rubocop:disable Rails/Date
       person = { email: 'e', name: 'n', time: Time.zone.now.to_time }
+      # rubocop:enable Rails/Date
       Rugged::Commit.create(repo, message: 'a new commit', tree: commit_tree,
                                   author: person, committer: person,
                                   parents: [repo.head.target].compact, update_ref: 'HEAD')

--- a/spec/diggit/analysis/temporary_analysis_repo.rb
+++ b/spec/diggit/analysis/temporary_analysis_repo.rb
@@ -47,7 +47,10 @@ class TemporaryAnalysisRepo
     commit_tree = repo.index.write_tree(repo)
     repo.index.write
 
+    # rubocop:disable Rails/Date
     person = { email: 'git@test.com', name: 'Test', time: time.to_time }
+    # rubocop:enable Rails/Date
+
     Rugged::Commit.
       create(repo,
              message: message,

--- a/spec/diggit/jobs/cron_job_spec.rb
+++ b/spec/diggit/jobs/cron_job_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe(Diggit::Jobs::CronJob) do
     let(:end_at) { start_end[1] }
 
     context 'when next period is today' do
-      let(:stubbed_now) { Time.parse('10:30') }
+      let(:stubbed_now) { Time.zone.parse('10:30') }
 
       it 'returns start and end of next period' do
         expect(start_at.to_date).to eql(stubbed_now.to_date)
@@ -30,7 +30,7 @@ RSpec.describe(Diggit::Jobs::CronJob) do
     end
 
     context 'when next end is tomorrow' do
-      let(:stubbed_now) { Time.parse('11:30') }
+      let(:stubbed_now) { Time.zone.parse('11:30') }
 
       it 'computes end_at to be tomorrow' do
         expect(start_at.to_date).to eql(stubbed_now.to_date)
@@ -42,7 +42,7 @@ RSpec.describe(Diggit::Jobs::CronJob) do
     end
 
     context 'when next period is tomorrow' do
-      let(:stubbed_now) { Time.parse('13:00') }
+      let(:stubbed_now) { Time.zone.parse('13:00') }
 
       it 'computes start and end to be tomorrow' do
         expect(start_at.to_date).to eql(tomorrow.to_date)


### PR DESCRIPTION
Once and for-all, Time.zone does not set `zone_default`, which is
what is used for the time zone of any new threads. Hence why Que
jobs were failing with nil zones, and any request threads.