### PR TITLE
Fix external git commands that are not terminating

### DIFF
--- a/lib/diggit/logger.rb
+++ b/lib/diggit/logger.rb
@@ -15,10 +15,18 @@ module Diggit
       Diggit.logger
     end
 
+    def log_payload(message)
+      { thread: Thread.current.object_id, pid: Process.pid,
+        class: self.class.to_s, message: message }
+    end
+
     %i(debug error fatal info log warn).each do |method|
       define_method(method) do |label = nil, &block|
-        Diggit.logger.send(method, label || self.class.to_s) do
-          [logger_prefix, block.call].compact.join(' ')
+        Diggit.logger.send(method) do
+          payload = block.call
+          payload = log_payload(payload) if payload.class == String
+          payload[:message] = [logger_prefix, payload[:message]].compact.join(' ')
+          payload.to_json
         end
       end
     end

--- a/lib/diggit/services/git_helpers.rb
+++ b/lib/diggit/services/git_helpers.rb
@@ -82,11 +82,14 @@ module Diggit
         opts << "--work-tree=#{repo.workdir}" unless repo.bare?
 
         io = IO.popen([GIT_BINARY, *opts, *args])
+        output = io.read
+
         _, status = Process.wait2(io.pid)
+        output += io.read
 
         fail("git command failed!\n\n#{output}") unless status == 0
 
-        io.read
+        output
       end
     end
   end

--- a/spec/diggit/analysis/pipeline_spec.rb
+++ b/spec/diggit/analysis/pipeline_spec.rb
@@ -89,9 +89,8 @@ RSpec.describe(Diggit::Analysis::Pipeline) do
     end
 
     it 'logs running each reporter' do
-      allow(pipeline.logger).to receive(:info) do |prefix, &block|
-        expect(prefix).to eql('Diggit::Analysis::Pipeline')
-        expect(block.call).to match(/\[\S+\] \S+\.\.\./)
+      allow(pipeline).to receive(:info) do |&block|
+        expect(block.call).to match(/\S+\.\.\./)
       end
       comments
     end

--- a/spec/diggit/jobs/configure_project_github_spec.rb
+++ b/spec/diggit/jobs/configure_project_github_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe(Diggit::Jobs::ConfigureProjectGithub) do
 
     it 'logs error' do
       expect(Diggit.logger).to receive(:error) do |_, &block|
-        expect(block.call).to eql('Failed to find project with id=999')
+        expect(JSON.parse(block.call)['message']).
+          to eql('Failed to find project with id=999')
       end
       run!
     end

--- a/spec/diggit/logger_spec.rb
+++ b/spec/diggit/logger_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe(Diggit::InstanceLogger) do
   context 'with no logger_prefix' do
     it 'calls Diggit.logger.method with block that yields message' do
       expect(Diggit.logger).to receive(:info) do |&block|
-        expect(block.call).to eql(message)
+        expect(JSON.parse(block.call)['message']).to eql(message)
       end
       instance.info { message }
     end
@@ -22,7 +22,7 @@ RSpec.describe(Diggit::InstanceLogger) do
 
     it 'calls Diggit.logger.method with block that yields prefixed method' do
       expect(Diggit.logger).to receive(:info) do |&block|
-        expect(block.call).to eql('[prefix] how you doin')
+        expect(JSON.parse(block.call)['message']).to eql('[prefix] how you doin')
       end
       instance.info { message }
     end


### PR DESCRIPTION
Git as a child process will stall until something reads from it's
stdout. Calling `wait2` on git's pid before reading from it's file
descriptor was resulting in deadlock during analysis jobs.