### PR TITLE
Prevent duplicate scheduling of cron jobs

### DIFF
--- a/lib/capistrano/tasks/que.rake
+++ b/lib/capistrano/tasks/que.rake
@@ -28,7 +28,7 @@ namespace :que do
     on roles(:worker) do
       within release_path do
         (1..fetch(:que_worker_count) / 2).each do |i|
-          next if test("[ -f #{shared_path}/que_worker_#{i}.pid ]")
+          next unless test("[ -f #{shared_path}/que_worker_#{i}.pid ]")
 
           info "[deploy:que] Killing que##{i} daemon"
           execute('start-stop-daemon',

--- a/spec/diggit/jobs/cron_job_spec.rb
+++ b/spec/diggit/jobs/cron_job_spec.rb
@@ -9,6 +9,21 @@ RSpec.describe(Diggit::Jobs::CronJob) do
 
   before { allow(job_class).to receive(:postgres_now).and_return(stubbed_now) }
   let(:schedule_at) { ['10:00', '11:00', '12:00'] }
+  let(:stubbed_now) { Time.zone.now }
+
+  def mock_job_count
+    Que.job_stats.find { |j| j['job_class'] == 'MockJob' }['count']
+  end
+
+  describe '.schedule' do
+    context 'when called twice' do
+      it 'does not reschedule' do
+        MockJob.schedule
+        expect(mock_job_count).to eql(1)
+        expect { MockJob.schedule }.not_to change { mock_job_count }
+      end
+    end
+  end
 
   describe '.next_start_end' do
     subject(:start_end) { job_class.next_start_end }


### PR DESCRIPTION
Fixes error where I'd get spammed with emails as four workers schedule the next cron. Also adjusts que stop process to actually kill the que workers!