### PR TITLE
Interpolates a min_support, improves changeset walking

### DIFF
--- a/lib/diggit/analysis/change_patterns/changeset_generator.rb
+++ b/lib/diggit/analysis/change_patterns/changeset_generator.rb
@@ -70,8 +70,8 @@ module Diggit
         def generate_commit_changesets
           walker.each_with_object([]) do |commit, commit_changesets|
             next unless commit.parents.size == 1
-            return commit_changesets if commit_changesets.size >= MAX_CHANGESETS ||
-                                        commits_in_cache.include?(commit.oid)
+            return commit_changesets if commit_changesets.size >= MAX_CHANGESETS
+
             commit_changesets << {
               oid: commit.oid,
               changeset: commit_diff(commit),
@@ -85,17 +85,16 @@ module Diggit
         end
 
         def commits_in_cache
-          @commits_in_cache ||= Hamster::Set.
-            new(changeset_cache.map { |entry| entry[:oid] })
+          @commits_in_cache ||= changeset_cache.map { |entry| entry[:oid] }
         end
 
         # Creates a new commit walker that will ignore commits already present in the
         # cache.
         def walker
           Rugged::Walker.new(repo).tap do |walker|
-            walker.simplify_first_parent
             walker.sorting(Rugged::SORT_DATE)
             walker.push(head)
+            walker.hide(commits_in_cache)
           end
         end
       end

--- a/spec/diggit/analysis/change_patterns/report_spec.rb
+++ b/spec/diggit/analysis/change_patterns/report_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe(Diggit::Analysis::ChangePatterns::Report) do
   let(:gh_path) { 'owner/repo' }
 
   before do
-    stub_const("#{described_class}::MIN_SUPPORT", min_support)
+    allow(described_class).to receive(:min_support_for).and_return(min_support)
     stub_const("#{described_class}::MIN_CONFIDENCE", min_confidence)
     stub_const("#{described_class}::MAX_CHANGESET_SIZE", max_changeset_size)
   end
@@ -77,6 +77,22 @@ RSpec.describe(Diggit::Analysis::ChangePatterns::Report) do
   let(:min_support) { 1 }
   let(:min_confidence) { 0.5 }
   let(:max_changeset_size) { 10 }
+
+  describe '.min_support_for' do
+    before { allow(described_class).to receive(:min_support_for).and_call_original }
+
+    it 'yields 5 for changesets sizes < 5,000' do
+      expect(described_class.min_support_for(3_000)).to equal(5)
+    end
+
+    it 'linearly interpolates by the thousand up to 10,000' do
+      expect(described_class.min_support_for(7_500)).to equal(7)
+    end
+
+    it 'caps out at 10 for anything over 10,000' do
+      expect(described_class.min_support_for(12_000)).to equal(10)
+    end
+  end
 
   describe '.comments' do
     subject(:comments) { report.comments }


### PR DESCRIPTION
Fixes walking so that it doesn't stop too early. Will be slower but probably more accurate, and as fp growth appears to be the limiting factor for runtime then this isn't a problem.

Adds a linearly interpolated value for `min_support` based on the number of changesets to analyse. Spitballing thresholds, will have to see if rails ever gets any suggestions.