### PR TITLE
Optimise file suggestion code

### DIFF
--- a/lib/diggit/analysis/change_patterns/file_suggester.rb
+++ b/lib/diggit/analysis/change_patterns/file_suggester.rb
@@ -7,6 +7,9 @@ module Diggit
         def initialize(frequent_itemsets, min_confidence: 0.75)
           @frequent_itemsets = frequent_itemsets
           @min_confidence = min_confidence
+          @itemset_support = frequent_itemsets.map do |frequent_itemset|
+            [frequent_itemset[:items].hash, frequent_itemset[:support]]
+          end.to_h
         end
 
         # Suggests files that frequently change with the given `files` with a confidence
@@ -18,7 +21,7 @@ module Diggit
         #     }
         #
         def suggest(files)
-          files = Hamster::Set.new(files)
+          files = Hamster::SortedSet.new(files)
 
           relevant_itemsets(files).each_with_object({}) do |itemset, suggestions|
             antecedent = files.intersection(itemset[:items])
@@ -55,7 +58,7 @@ module Diggit
         end
 
         def support_for(items)
-          frequent_itemsets.find { |is| is[:items] == items }.fetch(:support)
+          @itemset_support[items.hash] || 0
         end
       end
     end

--- a/lib/diggit/analysis/change_patterns/fp_growth.rb
+++ b/lib/diggit/analysis/change_patterns/fp_growth.rb
@@ -68,7 +68,7 @@ module Diggit
         # with > min_support.
         def frequent_itemsets(tree = initial_tree,
                               itemsets = Set.new,
-                              prefix = Hamster::Set[])
+                              prefix = Hamster::SortedSet[])
           tree.heads.
             reject { |item, head| head.count < min_support }.
             each do  |item, head|

--- a/lib/tasks/frequent_pattern.rb
+++ b/lib/tasks/frequent_pattern.rb
@@ -2,6 +2,15 @@
 namespace :frequent_pattern do
   BENCHMARK_TASK_ARGS = [:support_range, :max_items, :no_of_changesets].freeze
 
+  def load_rails_changesets(limit = 10_000)
+    require 'rugged'
+    require 'diggit/services/cache'
+
+    Diggit::Services::Cache.get('frequent_pattern/rails/changesets').
+      map { |entry| entry[:changeset] }.
+      first(limit)
+  end
+
   desc 'Walk rails repository to fill changeset cache'
   task :walk_rails, [:rails_path] do |_, args|
     require 'diggit/analysis/change_patterns/changeset_generator'
@@ -17,6 +26,48 @@ namespace :frequent_pattern do
     puts("Loaded #{changesets.size} changesets into cache!")
   end
 
+  desc 'Benchmarks file suggestion'
+  task :benchmark_file_suggestion do
+    require 'benchmark'
+    require 'hamster'
+    require 'diggit/services/cache'
+    require 'diggit/analysis/change_patterns/file_suggester'
+
+    itemsets = Diggit::Services::Cache.get('frequent_pattern/rails/itemsets').
+      map { |is| { items: Hamster::SortedSet.new(is['items']), support: is['support'] } }
+    puts("Loaded #{itemsets.size} changesets!")
+
+    suggester = Diggit::Analysis::ChangePatterns::FileSuggester.new(itemsets)
+    files = ['activerecord/lib/active_record/connection_adapters/abstract_adapter.rb',
+             'activerecord/lib/active_record/connection_adapters/sqlite3_adapter.rb']
+
+    puts('Starting...')
+    suggestions = nil
+    run_time = Benchmark.measure do
+      suggestions = suggester.suggest(files)
+    end
+    puts("Found #{suggestions.count} suggestions!")
+    puts("#{run_time}\n")
+  end
+
+  desc 'Loads rails frequent itemsets into cache'
+  task :generate_rails_itemsets do
+    require 'diggit/services/cache'
+    require 'diggit/analysis/change_patterns/fp_growth'
+
+    changesets = load_rails_changesets(10_000)
+    puts("Loaded #{changesets.size} changesets!")
+
+    patterns = Diggit::Analysis::ChangePatterns::FpGrowth.
+      new(changesets,
+          min_support: 5,
+          max_items: 25).frequent_itemsets
+    puts("Found #{patterns.size} frequent itemsets!")
+
+    Diggit::Services::Cache.store('frequent_pattern/rails/itemsets', patterns.as_json)
+    puts('Done!')
+  end
+
   # Runs and profiles blocks that generate frequent pattern sets from the rails
   # changesets.
   def benchmark_fp_discovery(algorithm, args, _dump_dir)
@@ -26,15 +77,12 @@ namespace :frequent_pattern do
 
     require 'diggit/services/cache'
 
-    # min_support = args.fetch(:min_support, 10).to_i
     support_range = Range.new(*args.fetch(:support_range).split('..').map(&:to_i))
     max_items = args.fetch(:max_items, 20).to_i
     no_of_changesets = args.fetch(:no_of_changesets, 10_000).to_i
     patterns = nil
 
-    changesets = Diggit::Services::Cache.get('frequent_pattern/rails/changesets').
-      map { |entry| entry[:changeset] }.
-      first(no_of_changesets)
+    changesets = load_rails_changesets(no_of_changesets)
     puts("Loaded #{changesets.size} changesets!")
 
     support_range.to_a.reverse.each do |min_support|

--- a/spec/diggit/analysis/change_patterns/file_suggester_spec.rb
+++ b/spec/diggit/analysis/change_patterns/file_suggester_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe(Diggit::Analysis::ChangePatterns::FileSuggester) do
 
   let(:frequent_itemsets) do
     load_json_fixture('frequent_pattern/diggit_frequent_patterns.json').map do |is|
-      { items: Hamster::Set.new(is['items']), support: is['support'] }
+      { items: Hamster::SortedSet.new(is['items']), support: is['support'] }
     end
   end
 
@@ -51,7 +51,7 @@ RSpec.describe(Diggit::Analysis::ChangePatterns::FileSuggester) do
           { items: %i(a b), support: 4 },
           { items: %i(b c), support: 3 },
           { items: %i(a b c), support: 3 },
-        ].map { |is| is.merge(items: Hamster::Set.new(is[:items])) }
+        ].map { |is| is.merge(items: Hamster::SortedSet.new(is[:items])) }
       end
 
       it 'will make a suggestion if a subset of the given files implies confidence' do


### PR DESCRIPTION
Prevents very expensive searches through large frequent itemset
collections. Makes use of the Hamster::SortedSet hashing to map
itemsets to support.

Reduces runs of tens of minutes to 3s for >500,000 itemsets.