### PR TITLE
Minimum support threshold discovery

### DIFF
--- a/db/migrate/20160602135423_add_min_support_to_projects.rb
+++ b/db/migrate/20160602135423_add_min_support_to_projects.rb
@@ -1,0 +1,5 @@
+class AddMinSupportToProjects < ActiveRecord::Migration
+  def change
+    add_column :projects, :min_support, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160525122444) do
+ActiveRecord::Schema.define(version: 20160602135423) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 20160525122444) do
     t.binary   "gh_token_initialization_vector"
     t.datetime "created_at"
     t.datetime "updated_at"
+    t.integer  "min_support",                                default: 0,     null: false
   end
 
   add_index "projects", ["gh_path"], name: "index_projects_on_gh_path", unique: true, using: :btree

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,14 +50,14 @@ ActiveRecord::Schema.define(version: 20160602135423) do
   add_index "pull_analyses", ["project_id"], name: "index_pull_analyses_on_project_id", using: :btree
 
   create_table "que_jobs", id: false, force: :cascade do |t|
-    t.integer  "priority",    limit: 2, default: 100,                                        null: false
-    t.datetime "run_at",                default: "now()",                                    null: false
-    t.integer  "job_id",      limit: 8, default: "nextval('que_jobs_job_id_seq'::regclass)", null: false
-    t.text     "job_class",                                                                  null: false
-    t.json     "args",                  default: [],                                         null: false
-    t.integer  "error_count",           default: 0,                                          null: false
+    t.integer  "priority",    limit: 2, default: 100,                   null: false
+    t.datetime "run_at",                default: '2016-04-07 10:06:35', null: false
+    t.integer  "job_id",      limit: 8, default: 0,                     null: false
+    t.text     "job_class",                                             null: false
+    t.json     "args",                  default: [],                    null: false
+    t.integer  "error_count",           default: 0,                     null: false
     t.text     "last_error"
-    t.text     "queue",                 default: "",                                         null: false
+    t.text     "queue",                 default: "",                    null: false
   end
 
   add_foreign_key "pull_analyses", "projects"

--- a/lib/diggit/analysis/change_patterns/min_support_finder.rb
+++ b/lib/diggit/analysis/change_patterns/min_support_finder.rb
@@ -1,0 +1,19 @@
+module Diggit
+  module Analysis
+    module ChangePatterns
+      # Discovers appropriate minimum support parameter for given changesets.
+      #
+      # Selects the minimum support that yields results in less than TIMEOUT
+      # seconds or that includes PCT_FILES_INCLUDED% of the given files in
+      # the repo.
+      class MinSupportFinder
+        TIMEOUT = 60.seconds
+        PCT_FILES_INCLUDED = 20
+
+        def initialize(algorithm, changesets)
+
+        end
+      end
+    end
+  end
+end

--- a/lib/diggit/analysis/change_patterns/min_support_finder.rb
+++ b/lib/diggit/analysis/change_patterns/min_support_finder.rb
@@ -1,17 +1,67 @@
+require 'hamster'
+require 'timeout'
+require_relative '../../logger'
+
 module Diggit
   module Analysis
     module ChangePatterns
       # Discovers appropriate minimum support parameter for given changesets.
       #
       # Selects the minimum support that yields results in less than TIMEOUT
-      # seconds or that includes PCT_FILES_INCLUDED% of the given files in
+      # seconds or that includes FILES_INCLUDED_THRESHOLD of the given files in
       # the repo.
       class MinSupportFinder
         TIMEOUT = 60.seconds
-        PCT_FILES_INCLUDED = 20
+        FILES_INCLUDED_THRESHOLD = 0.3
+        INITIAL_SUPPORT = 20
 
-        def initialize(algorithm, changesets)
+        include InstanceLogger
 
+        def initialize(algorithm, changesets, current_files)
+          @algorithm = algorithm
+          @changesets = changesets
+          @current_files = Hamster::SortedSet.new(current_files)
+        end
+
+        def support
+          @support ||= generate_support
+        end
+
+        private
+
+        attr_reader :algorithm, :changesets, :current_files
+
+        def generate_support
+          INITIAL_SUPPORT.downto(2).each do |min_support|
+            files_included = benchmark(min_support)
+
+            return min_support + 1 if files_included.nil? # timed out
+            return min_support if files_included > FILES_INCLUDED_THRESHOLD
+          end
+
+          2
+        end
+
+        def benchmark(min_support)
+          info { "Benchmarking min_support=#{min_support}..." }
+          frequent_itemsets = Timeout.timeout(10.seconds) do
+            algorithm.
+              new(changesets, min_support: min_support).
+              frequent_itemsets
+          end
+          info { "Found #{frequent_itemsets.size} frequent itemsets!" }
+
+          ratio_files_included(frequent_itemsets)
+        rescue Timeout::Error
+          info { "Timeout for min_support=#{min_support}!" }
+          nil
+        end
+
+        def ratio_files_included(itemsets)
+          files_in_patterns = itemsets.map { |p| p[:items] }.inject(:+)
+          return 0.0 if files_in_patterns.nil?
+
+          current_files.intersection(files_in_patterns).size / current_files.size.to_f
         end
       end
     end

--- a/lib/diggit/services/git_helpers.rb
+++ b/lib/diggit/services/git_helpers.rb
@@ -10,6 +10,10 @@ module Diggit
     module GitHelpers
       GIT_BINARY = 'git'.freeze
 
+      def initialize(repo)
+        @repo = repo
+      end
+
       # Runs the rev-list command, returning an array of commit shas that are ancestors of
       # the given commit, filtered by path if one is supplied.
       def rev_list(commit:, path: nil)

--- a/spec/diggit/analysis/change_patterns/min_support_finder_spec.rb
+++ b/spec/diggit/analysis/change_patterns/min_support_finder_spec.rb
@@ -1,0 +1,81 @@
+require 'diggit/analysis/change_patterns/min_support_finder'
+require 'diggit/analysis/change_patterns/fp_growth'
+
+RSpec.describe(Diggit::Analysis::ChangePatterns::MinSupportFinder) do
+  subject(:finder) { described_class.new(algorithm, changesets, current_files) }
+
+  let(:algorithm) { Diggit::Analysis::ChangePatterns::FpGrowth }
+  let(:changesets) { [] }
+  let(:current_files) { %w(a.rb b.rb c.rb d.rb e.rb) }
+
+  let(:grower_instant_below_threshold) do
+    instance_of(algorithm).tap do |grower|
+      allow(grower).to receive(:frequent_itemsets).
+        and_return([ # 20%!
+                     { items: Hamster::SortedSet['c.rb'], support: 2 },
+                   ])
+    end
+  end
+
+  let(:grower_instant_above_threshold) do
+    instance_of(algorithm).tap do |grower|
+      allow(grower).to receive(:frequent_itemsets).
+        and_return([ # 60%!
+                     { items: Hamster::SortedSet['a.rb', 'b.rb'], support: 3 },
+                     { items: Hamster::SortedSet['c.rb'], support: 2 },
+                   ])
+    end
+  end
+
+  let(:grower_timeout) do
+    instance_of(algorithm).tap do |grower|
+      allow(grower).to receive(:frequent_itemsets) do
+        raise(Timeout::Error)
+      end
+    end
+  end
+
+  let(:timeout) { 1.second }
+  let(:files_included_threshold) { 0.3 }
+  let(:initial_support) { 10 }
+
+  before do
+    stub_const("#{described_class}::TIMEOUT", timeout)
+    stub_const("#{described_class}::FILES_INCLUDED_THRESHOLD", files_included_threshold)
+    stub_const("#{described_class}::INITIAL_SUPPORT", initial_support)
+  end
+
+  # Allow Algorithm being instantiated with `min_support` to yield `grower`
+  def mock_grower(min_support, grower)
+    allow(algorithm).
+      to receive(:new).
+      with(changesets, min_support: min_support).
+      and_return(grower)
+  end
+
+  describe '.support' do
+    context 'when limited by algorithm performance' do
+      before do
+        mock_grower(initial_support - 0, grower_instant_below_threshold)
+        mock_grower(initial_support - 1, grower_instant_below_threshold)
+        mock_grower(initial_support - 2, grower_timeout)
+      end
+
+      it 'returns the next best support value' do
+        expect(finder.support).to be(initial_support - 1)
+      end
+    end
+
+    context 'when threshold is reached before timeout' do
+      before do
+        mock_grower(initial_support - 0, grower_instant_below_threshold)
+        mock_grower(initial_support - 1, grower_instant_below_threshold)
+        mock_grower(initial_support - 2, grower_instant_above_threshold)
+      end
+
+      it 'returns support value that yields threshold' do
+        expect(finder.support).to be(initial_support - 2)
+      end
+    end
+  end
+end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -3,6 +3,7 @@ FactoryGirl.define do
     sequence(:gh_path) { |n| "lawrencejones/#{n}" }
     watch false
     silent false
+    min_support 0
 
     trait :watched do
       watch true


### PR DESCRIPTION
Identifies the appropriate minimum support as that which allows running analysis in <60s and produces frequent itemsets that include 30% of files in latest commit.