### PR TITLE
Cache 25,000 changesets, include master only

### DIFF
--- a/lib/diggit/analysis/change_patterns/changeset_generator.rb
+++ b/lib/diggit/analysis/change_patterns/changeset_generator.rb
@@ -14,7 +14,7 @@ module Diggit
         include Services::GitHelpers
 
         # Specify how many changesets to keep in storage
-        MAX_CHANGESETS = 10_000
+        MAX_CHANGESETS = 25_000
 
         def initialize(repo, gh_path:, head: nil)
           @repo = Rugged::Repository.new(repo.workdir)

--- a/lib/diggit/analysis/change_patterns/report.rb
+++ b/lib/diggit/analysis/change_patterns/report.rb
@@ -83,8 +83,10 @@ module Diggit
 
         def changesets
           @changesets ||= ChangesetGenerator.
-            # Use base to avoid including commits that may not be merged into master
-            new(repo, head: base, gh_path: gh_path).
+            # Use the master branch to avoid including commits that may not be merged
+            new(repo,
+                gh_path: gh_path,
+                head: repo.branches['origin/master'].try(:target).try(:oid) || base).
             changesets
         end
       end

--- a/lib/tasks/analysis.rb
+++ b/lib/tasks/analysis.rb
@@ -6,6 +6,17 @@ namespace :analysis do
       uniq
   end
 
+  desc 'Flushes redis cache and resets min_support params'
+  task :reset do
+    require 'diggit/models/project'
+    require 'diggit/services/cache'
+
+    puts("Flushing redis cache: #{Diggit::Services::Cache.conn.flushall}")
+
+    updated = Project.update_all(min_support: 0)
+    puts("Reset min_support on #{updated} projects")
+  end
+
   desc 'Runs an analysis on the given pull'
   task :run, [:gh_path, :pull] do |_, args|
     require 'diggit/github/client'


### PR DESCRIPTION
Change changeset limit to 25k, start generating changesets using the head of the master branch.