### PR TITLE
Removes location from change patterns comment

### DIFF
--- a/lib/diggit/analysis/change_patterns/report.rb
+++ b/lib/diggit/analysis/change_patterns/report.rb
@@ -38,7 +38,7 @@ module Diggit
           likely_missing_files.map do |file, confidence:, antecedent:|
             { report: 'ChangePatterns',
               index: file,
-              location: "#{file}:1",
+              location: nil, # aggregate comments for this reporter
               message: "Expected `#{file}` to change, as it was modified in "\
                        "#{(100 * confidence).to_i}% of past changes involving "\
                        "#{antecedent.map { |changed| "`#{changed}`" }.join(' ')}",

--- a/lib/diggit/github/comment_generator.rb
+++ b/lib/diggit/github/comment_generator.rb
@@ -16,10 +16,10 @@ module Diggit
 
       # Batch and send comments to github
       def push
-        @client.add_comment(repo, pull, comments.join("\n")) unless comments.empty?
+        @client.add_comment(repo, pull, comments.join("\n\n")) unless comments.empty?
         comments_by_file.each do |file_diff_index, comments|
           file, diff_index = parse_location(file_diff_index)
-          body = comments.join("\n")
+          body = comments.join("\n\n")
 
           @client.create_pull_comment(repo, pull, body, diff.head, file, diff_index)
         end

--- a/spec/diggit/analysis/change_patterns/report_spec.rb
+++ b/spec/diggit/analysis/change_patterns/report_spec.rb
@@ -141,7 +141,7 @@ RSpec.describe(Diggit::Analysis::ChangePatterns::Report) do
         expect(controller_comment).to include(
           report: 'ChangePatterns',
           index: 'app_controller.rb',
-          location: 'app_controller.rb:1',
+          location: nil,
           message: /was modified in 75% of past changes involving/,
           meta: {
             missing_file: 'app_controller.rb',

--- a/spec/diggit/github/comment_generator_spec.rb
+++ b/spec/diggit/github/comment_generator_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe(Diggit::Github::CommentGenerator) do
       generator.add_comment('hello')
       generator.add_comment('world')
 
-      expect(client).to receive(:add_comment).with(repo, pull, "hello\nworld")
+      expect(client).to receive(:add_comment).with(repo, pull, "hello\n\nworld")
       generator.push
     end
 
@@ -45,7 +45,7 @@ RSpec.describe(Diggit::Github::CommentGenerator) do
 
         expect(client).
           to receive(:create_pull_comment).
-          with(repo, pull, "hello\nworld", 'head-sha', 'Gemfile.rb', 7)
+          with(repo, pull, "hello\n\nworld", 'head-sha', 'Gemfile.rb', 7)
         generator.push
       end
     end


### PR DESCRIPTION
This resulted in really messy output for multiple change pattern
comments and arguably duplicated information, given the message
references the file directly by path.