### PR TITLE
`.diggit.yml`

### DIFF
--- a/lib/diggit/analysis/change_patterns/min_support_finder.rb
+++ b/lib/diggit/analysis/change_patterns/min_support_finder.rb
@@ -15,6 +15,17 @@ module Diggit
         FILES_INCLUDED_THRESHOLD = 0.3
         INITIAL_SUPPORT = 20
 
+        def self.find(project, changesets, current_files, algorithm = FpGrowth)
+          unless project.min_support > 0
+            info { 'Finding appropriate min_support parameter...' }
+            min_support = new(algorithm, changesets, current_files).support
+            info { "Updating project with min_support=#{min_support}..." }
+            project.update!(min_support: min_support)
+          end
+
+          project.min_support
+        end
+
         include InstanceLogger
 
         def initialize(algorithm, changesets, current_files)

--- a/lib/diggit/analysis/change_patterns/report.rb
+++ b/lib/diggit/analysis/change_patterns/report.rb
@@ -16,13 +16,16 @@ module Diggit
         include Services::GitHelpers
         include InstanceLogger
 
-        def initialize(repo, conf)
+        def initialize(repo, args, config)
           @repo = repo
-          @base = conf.fetch(:base)
-          @head = conf.fetch(:head)
-          @gh_path = conf.fetch(:gh_path)
-          @project = Project.find_by!(gh_path: @gh_path)
+          @base = args.fetch(:base)
+          @head = args.fetch(:head)
+          @gh_path = args.fetch(:gh_path)
 
+          @min_confidence = config.fetch(:min_confidence, MIN_CONFIDENCE)
+          @ignore = config.fetch(:ignore, {})
+
+          @project = Project.find_by!(gh_path: @gh_path)
           @logger_prefix = "[#{gh_path}]"
         end
 
@@ -54,7 +57,7 @@ module Diggit
         def likely_missing_files
           FileSuggester.
             new(frequent_itemsets,
-                min_confidence: MIN_CONFIDENCE).
+                min_confidence: @min_confidence).
             suggest(files_modified(base: base, head: head))
         end
 

--- a/lib/diggit/analysis/complexity/report.rb
+++ b/lib/diggit/analysis/complexity/report.rb
@@ -6,6 +6,7 @@ module Diggit
   module Analysis
     module Complexity
       class Report
+        NAME = 'Complexity'.freeze
         IGNORED_EXTENSIONS = %w(.json .xml .yml .yaml).freeze
         CHANGE_WINDOW = 3
         CHANGE_THRESHOLD = 50.0
@@ -43,7 +44,7 @@ module Diggit
 
         def generate_comments
           paths_above_threshold.to_h.map do |path, (complexity_increase, head, base)|
-            { report: 'Complexity',
+            { report: self.class::NAME,
               index: path,
               location: "#{path}:1",
               message: "`#{path}` has increased in complexity by "\

--- a/lib/diggit/analysis/complexity/report.rb
+++ b/lib/diggit/analysis/complexity/report.rb
@@ -6,7 +6,7 @@ module Diggit
   module Analysis
     module Complexity
       class Report
-        IGNORED_EXTENSIONS = %w(.json .xml .yaml).freeze
+        IGNORED_EXTENSIONS = %w(.json .xml .yml .yaml).freeze
         CHANGE_WINDOW = 3
         CHANGE_THRESHOLD = 50.0
 
@@ -23,10 +23,14 @@ module Diggit
                                     include_seconds: false)
         end
 
-        def initialize(repo, conf)
+        def initialize(repo, args, config)
           @repo = repo
-          @base = conf.fetch(:base)
-          @head = conf.fetch(:head)
+          @base = args.fetch(:base)
+          @head = args.fetch(:head)
+
+          @change_window = config.fetch(:change_window, CHANGE_WINDOW)
+          @change_threshold = config.fetch(:change_threshold, CHANGE_THRESHOLD)
+          @ignore = config.fetch(:ignore, [])
         end
 
         def comments
@@ -58,12 +62,12 @@ module Diggit
         # complexity history.
         def paths_above_threshold
           path_complexity_change.select do |_, (complexity_increase)|
-            complexity_increase >= CHANGE_THRESHOLD
+            complexity_increase >= @change_threshold
           end
         end
 
         # Computes how much the complexity of the path has increased, in percentage,
-        # over the last CHANGE_WINDOW changes.
+        # over the last @change_window changes.
         #
         #   { 'file.rb' => [56.8, latest_commitish, lowest_committish] }
         #
@@ -97,7 +101,7 @@ module Diggit
         #
         def path_complexity_history
           @path_complexity_history ||= path_changes.map do |path, changes|
-            [path, changes.first(CHANGE_WINDOW).map do |commit|
+            [path, changes.first(@change_window).map do |commit|
               file_content = cat_file(path: path, commit: commit) || ''
               [commit, self.class.compute_complexity(file_content)]
             end]
@@ -119,13 +123,10 @@ module Diggit
           end.reject { |_, history| history.empty? }
         end
 
-        # All paths that should be scanned for complexity growth.
         def tracked_paths
-          @tracked_paths ||= repo.
-            diff(repo.merge_base(base, head), head).deltas.
-            reject { |delta| delta.status == :deleted }.
-            map { |delta| delta.new_file[:path] }.
-            reject { |path| IGNORED_EXTENSIONS.include?(File.extname(path)) }
+          @tracked_paths ||= files_modified(base: base, head: head).
+            reject { |path| IGNORED_EXTENSIONS.include?(File.extname(path)) }.
+            reject { |path| @ignore.include?(path) }
         end
       end
     end

--- a/lib/diggit/analysis/pipeline.rb
+++ b/lib/diggit/analysis/pipeline.rb
@@ -15,6 +15,7 @@ module Diggit
         ChangePatterns::Report,
       ].freeze
 
+      DIGGIT_CONFIG_FILE = '.diggit.yml'
       MAX_FILES_CHANGED = 25
 
       # [ 'RefactorDiligence', 'Complexity', ... ]
@@ -42,7 +43,12 @@ module Diggit
         REPORTERS.map do |report|
           info { "#{report}..." }
           repo.reset(head, :hard)
-          report.new(repo, base: base, head: head, gh_path: gh_path).comments
+          report.
+            new(repo,
+                base: base, head: head,
+                gh_path: gh_path,
+                config: reporter_config.fetch(report, {})).
+            comments
         end.flatten
       end
 
@@ -64,6 +70,11 @@ module Diggit
 
       def no_files_changed
         @no_files_changed = files_modified(base: base, head: head).count
+      end
+
+      def reporter_config
+        @reporter_config ||= YAML.
+          load(cat_file(commit: head, path: DIGGIT_CONFIG_FILE) || '{}')
       end
     end
   end

--- a/lib/diggit/analysis/refactor_diligence/report.rb
+++ b/lib/diggit/analysis/refactor_diligence/report.rb
@@ -7,6 +7,7 @@ module Diggit
   module Analysis
     module RefactorDiligence
       class Report
+        NAME = 'RefactorDiligence'.freeze
         TIMES_INCREASED_THRESHOLD = 3
         MIN_METHOD_SIZE = 6
 
@@ -33,7 +34,7 @@ module Diggit
 
         def generate_comments
           methods_over_threshold.to_h.map do |method, history|
-            { report: 'RefactorDiligence',
+            { report: self.class::NAME,
               index: method,
               location: method_locations.fetch(method),
               message: "`#{method}` has increased in size the last "\

--- a/lib/diggit/analysis/refactor_diligence/report.rb
+++ b/lib/diggit/analysis/refactor_diligence/report.rb
@@ -12,14 +12,19 @@ module Diggit
 
         include Services::GitHelpers
 
-        def initialize(repo, conf)
+        def initialize(repo, args, config)
           @repo = repo
-          @base = conf.fetch(:base)
-          @head = conf.fetch(:head)
+          @base = args.fetch(:base)
+          @head = args.fetch(:head)
+
+          @min_method_size = config.fetch(:min_method_size, MIN_METHOD_SIZE)
+          @times_increased_threshold = config.
+            fetch(:times_increased_threshold, TIMES_INCREASED_THRESHOLD)
+          @ignore = config.fetch(:ignore, [])
         end
 
         def comments
-          @comments ||= parseable_files_changed.empty? ? [] : generate_comments
+          @comments ||= tracked_paths.empty? ? [] : generate_comments
         end
 
         private
@@ -49,8 +54,8 @@ module Diggit
         def methods_over_threshold
           @methods_over_threshold ||= method_size_history.
             select { |_, history| commits_in_diff.include?(history.first[1].oid) }.
-            each   { |_, history| history.select! { |(size)| size > MIN_METHOD_SIZE } }.
-            select { |_, history| history.size > TIMES_INCREASED_THRESHOLD }
+            each   { |_, history| history.select! { |(size)| size > @min_method_size } }.
+            select { |_, history| history.size > @times_increased_threshold }
         end
 
         # Parses all the changed files changed in head to identify the location of each
@@ -59,7 +64,7 @@ module Diggit
         #   { 'method' => 'file.rb:4', ... }
         #
         def method_locations
-          @method_locations ||= parseable_files_changed.
+          @method_locations ||= tracked_paths.
             map { |file| [file, cat_file(commit: head, path: file)] }.
             map { |(file, contents)| MethodParser.parse(contents, file: file).methods }.
             inject(:merge).
@@ -68,7 +73,7 @@ module Diggit
 
         def method_size_history
           MethodSizeHistory.
-            new(repo, head: head, files: parseable_files_changed).
+            new(repo, head: head, files: tracked_paths).
             history
         end
 
@@ -76,12 +81,10 @@ module Diggit
           @commits_in_diff ||= commits_between(base, head).map(&:oid)
         end
 
-        def parseable_files_changed
-          @parseable_files_changed ||= repo.
-            diff(repo.merge_base(base, head), head).deltas.
-            reject { |delta| delta.status == :deleted }.
-            map { |delta| delta.new_file[:path] }.
-            select { |file| MethodParser.supported?(file) }
+        def tracked_paths
+          @tracked_paths ||= files_modified(base: base, head: head).
+            select { |file| MethodParser.supported?(file) }.
+            reject { |file| @ignore.include?(file) }
         end
       end
     end

--- a/lib/diggit/logger.rb
+++ b/lib/diggit/logger.rb
@@ -15,6 +15,10 @@ module Diggit
       Diggit.logger
     end
 
+    def self.included(base)
+      base.extend(InstanceLogger)
+    end
+
     def log_payload(message)
       { thread: Thread.current.object_id, pid: Process.pid,
         class: self.class.to_s, message: message }

--- a/spec/diggit/analysis/change_patterns/report_spec.rb
+++ b/spec/diggit/analysis/change_patterns/report_spec.rb
@@ -60,7 +60,9 @@ end
 # rubocop:enable Metrics/MethodLength
 
 RSpec.describe(Diggit::Analysis::ChangePatterns::Report) do
-  subject(:report) { described_class.new(repo, head: head, base: base, gh_path: gh_path) }
+  subject(:report) do
+    described_class.new(repo, { head: head, base: base, gh_path: gh_path }, config)
+  end
 
   let(:head) { repo.branches.find { |b| b.name == 'feature' }.target.oid }
   let(:base) { repo.branches.find { |b| b.name == 'master' }.target.oid }
@@ -73,13 +75,13 @@ RSpec.describe(Diggit::Analysis::ChangePatterns::Report) do
   end
   let(:project_min_support) { 1 }
 
-  before do
-    stub_const("#{described_class}::MIN_CONFIDENCE", min_confidence)
-    stub_const("#{described_class}::MAX_CHANGESET_SIZE", max_changeset_size)
-  end
-
+  let(:config) { { min_confidence: min_confidence, ignore: ignore } }
   let(:min_confidence) { 0.5 }
+  let(:ignore) { {} }
+
+  before { stub_const("#{described_class}::MAX_CHANGESET_SIZE", max_changeset_size) }
   let(:max_changeset_size) { 10 }
+
   let(:files_in_last_commit) do
     %w(Gemfile app.rb app_controller.rb app_template.html).freeze
   end

--- a/spec/diggit/analysis/complexity/report_spec.rb
+++ b/spec/diggit/analysis/complexity/report_spec.rb
@@ -24,12 +24,19 @@ def complexity_test_repo
 end
 
 RSpec.describe(Diggit::Analysis::Complexity::Report) do
-  subject(:report) { described_class.new(repo, base: base, head: head) }
+  subject(:report) { described_class.new(repo, { base: base, head: head }, config) }
 
   let(:head) { repo.branches.find { |b| b.name == 'feature' }.target.oid }
   let(:base) { repo.branches.find { |b| b.name == 'master' }.target.oid }
 
   let(:repo) { complexity_test_repo }
+
+  let(:config) do
+    { change_window: change_window, change_threshold: change_threshold, ignore: ignore }
+  end
+  let(:change_threshold) { 50.0 }
+  let(:change_window) { 3 }
+  let(:ignore) { [] }
 
   # Stub the complexity scores, to allow testing detection logic without contrived
   # code examples
@@ -82,6 +89,21 @@ RSpec.describe(Diggit::Analysis::Complexity::Report) do
               head: /^\S{40}$/, base: /^\S{40}$/
             }
           )
+        end
+
+        context 'when user defined threshold is greater than change' do
+          let(:change_threshold) { 75.0 }
+          it { is_expected.to be_empty }
+        end
+
+        context 'when user defined window is smalled than current' do
+          let(:change_window) { 2 }
+          it { is_expected.to be_empty }
+        end
+
+        context 'and file is in ignore list' do
+          let(:ignore) { ['master.rb'] }
+          it { is_expected.to be_empty }
         end
       end
 

--- a/spec/diggit/analysis/complexity/report_spec.rb
+++ b/spec/diggit/analysis/complexity/report_spec.rb
@@ -47,6 +47,10 @@ RSpec.describe(Diggit::Analysis::Complexity::Report) do
       end
   end
 
+  it 'defines a name' do
+    expect(described_class::NAME).to eql('Complexity')
+  end
+
   describe '.comments' do
     subject(:comments) { report.comments }
     let(:master_comment) { comments.find { |c| c[:meta][:file][/master.rb/] } }

--- a/spec/diggit/analysis/refactor_diligence/report_spec.rb
+++ b/spec/diggit/analysis/refactor_diligence/report_spec.rb
@@ -141,6 +141,10 @@ RSpec.describe(Diggit::Analysis::RefactorDiligence::Report) do
   let(:min_method_size) { 1 }
   let(:ignore) { [] }
 
+  it 'defines a name' do
+    expect(described_class::NAME).to eql('RefactorDiligence')
+  end
+
   describe '#comments' do
     subject(:comments) { report.comments }
 

--- a/spec/diggit/analysis/temporary_analysis_repo.rb
+++ b/spec/diggit/analysis/temporary_analysis_repo.rb
@@ -5,7 +5,10 @@ class TemporaryAnalysisRepo
   @repos = []
 
   def self.create(&block)
-    new.tap(&block).repo
+    new.tap do |repo|
+      repo.commit('Initial commit')
+      block.call(repo)
+    end.rugged
   end
 
   def self.clean!
@@ -14,55 +17,55 @@ class TemporaryAnalysisRepo
 
   def self.schedule_for_removal(repo)
     @repos << repo
+    @repos.uniq! { |r| r.rugged.workdir }
   end
 
   def initialize(base = Dir.mktmpdir)
-    @repo = Rugged::Repository.init_at(base)
-    commit('Initial commit')
+    @rugged = Rugged::Repository.init_at(base)
     self.class.schedule_for_removal(self)
   end
 
-  attr_reader :repo
+  attr_reader :rugged
 
   def branch(branch)
-    repo.branches.create(branch, 'HEAD')
-    repo.checkout(branch)
+    rugged.branches.create(branch, 'HEAD')
+    rugged.checkout(branch)
   end
 
   def write(path, contents)
-    repo.index.tap do |index|
-      filepath = File.join(repo.workdir, path)
+    rugged.index.tap do |index|
+      filepath = File.join(rugged.workdir, path)
       FileUtils.mkdir_p(File.dirname(filepath))
       File.write(filepath, contents)
-      index.add(path: path, oid: Rugged::Blob.from_workdir(repo, path), mode: 0100644)
+      index.add(path: path, oid: Rugged::Blob.from_workdir(rugged, path), mode: 0100644)
     end
   end
 
   def rm(path)
-    repo.index.tap do |index|
-      File.unlink(File.join(repo.workdir, path))
+    rugged.index.tap do |index|
+      File.unlink(File.join(rugged.workdir, path))
       index.remove(path)
     end
   end
 
   def commit(message, time: Time.zone.now)
-    commit_tree = repo.index.write_tree(repo)
-    repo.index.write
+    commit_tree = rugged.index.write_tree(rugged)
+    rugged.index.write
 
     # rubocop:disable Rails/Date
     person = { email: 'git@test.com', name: 'Test', time: time.to_time }
     # rubocop:enable Rails/Date
 
     Rugged::Commit.
-      create(repo,
+      create(rugged,
              message: message,
              tree: commit_tree,
              author: person, committer: person,
-             parents: repo.empty? ? [] : [repo.head.target].compact,
+             parents: rugged.empty? ? [] : [rugged.head.target].compact,
              update_ref: 'HEAD')
   end
 
   def destroy
-    FileUtils.rm_rf(repo.workdir)
+    FileUtils.rm_rf(rugged.workdir)
   end
 end


### PR DESCRIPTION
Support `.diggit.yml` files for specifying project settings for each reporter.

Example to ignore `Gemfile` suggestions when `Gemfile.lock` changes...
```yaml
ChangePatterns:
  ignore:
    Gemfile: [Gemfile.lock]
```
Also adds the above as a special case for gc config.